### PR TITLE
Fix for PAXEXAM-351.

### DIFF
--- a/core/pax-exam-spi/src/main/java/org/ops4j/pax/exam/spi/DefaultExamSystem.java
+++ b/core/pax-exam-spi/src/main/java/org/ops4j/pax/exam/spi/DefaultExamSystem.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import com.google.common.io.Files;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.ops4j.io.FileUtils;
 import org.ops4j.pax.exam.ExamSystem;
 import org.ops4j.pax.exam.Info;
 import org.ops4j.pax.exam.Option;
@@ -211,7 +212,7 @@ public class DefaultExamSystem implements ExamSystem {
                 for( ExamSystem sys : m_subsystems ) {
                     sys.clear();
                 }
-                Files.deleteRecursively( m_cache.getCanonicalFile() );
+                FileUtils.delete( m_cache.getCanonicalFile() );
 
             }
         } catch( IOException e ) {


### PR DESCRIPTION
Replaced call to Files.deleteRecursively(File) by FileUtils.delete(File).
