### PR TITLE
Move forked container dependency from exam-maven-plugin to regression-maven-plugin

### DIFF
--- a/itest/osgi/src/it/regression-maven-plugin/pom.xml
+++ b/itest/osgi/src/it/regression-maven-plugin/pom.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-forked</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <scope>test</scope>

--- a/maven/exam-maven-plugin/pom.xml
+++ b/maven/exam-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
 
     <name>OPS4J Pax Exam - Maven Plugin</name>
     <description>
-        Starts and stops a Forked Container in server mode.
+        Starts and stops a container in server mode.
     </description>
 
     <dependencies>
@@ -41,7 +41,7 @@
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-container-forked</artifactId>
+            <artifactId>pax-exam-spi</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
As described in [PAXEXAM-528](https://ops4j1.jira.com/browse/PAXEXAM-528), we would like to start a different container for integration tests, so I moved the forked container dependency to the test project.
