### PR TITLE
Change KarafTestContainer to rely directly on options and KarafPropertiesFile

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/ExamFeaturesFile.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/ExamFeaturesFile.java
@@ -112,9 +112,9 @@ public class ExamFeaturesFile {
     public void adaptDistributionToStartExam(File karafHome, File featuresXmlFile) throws IOException {
         KarafPropertiesFile karafPropertiesFile = new KarafPropertiesFile(karafHome, Constants.FEATURES_CFG_LOCATION);
         karafPropertiesFile.load();
-        String finalFilePath = ",file:" + featuresXmlFile.toString().replaceAll("\\\\", "/").replaceAll(" ", "%20");
+        String finalFilePath = "file:" + featuresXmlFile.toString().replaceAll("\\\\", "/").replaceAll(" ", "%20");
         karafPropertiesFile.extend("featuresRepositories", finalFilePath);
-        karafPropertiesFile.extend("featuresBoot", ",exam");
+        karafPropertiesFile.extend("featuresBoot", "exam");
         karafPropertiesFile.store();
     }
 

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafPropertiesFile.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafPropertiesFile.java
@@ -23,6 +23,10 @@ import java.io.IOException;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionConfigurationFileExtendOption;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionConfigurationFileOption;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionConfigurationFilePutOption;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionConfigurationFileReplacementOption;
 
 public class KarafPropertiesFile {
 
@@ -50,12 +54,16 @@ public class KarafPropertiesFile {
         properties.put(key, value);
     }
 
-    public void extend(String key, String value) {
+    public void extend(String key, String separator, String value) {
         if (properties.get(key) == null) {
             properties.put(key, value);
             return;
         }
-        properties.put(key, properties.get(key) + value);
+        properties.put(key, properties.get(key) + separator + value);
+    }
+
+    public void extend(String key, String value) {
+        extend(key, ",", value);
     }
 
     public String get(String key) {
@@ -72,6 +80,21 @@ public class KarafPropertiesFile {
         } 
         catch (IOException e) {
             throw new IllegalStateException("It is required to replace propertyFile");
+        }
+    }
+
+    /**
+     * Method used for delegating handling of the options to karaf property file.
+     * 
+     * @param option Option to be applied for given configuration file.
+     */
+    public void handle(KarafDistributionConfigurationFileOption option) {
+        if (option instanceof KarafDistributionConfigurationFilePutOption) {
+            put(option.getKey(), option.getValue());
+        } else if (option instanceof KarafDistributionConfigurationFileExtendOption) {
+            extend(option.getKey(), option.getSeparator(), option.getValue());
+        } else if (option instanceof KarafDistributionConfigurationFileReplacementOption) {
+            replace(((KarafDistributionConfigurationFileReplacementOption) option).getSource());
         }
     }
 

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafBootFeatureOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafBootFeatureOption.java
@@ -1,0 +1,14 @@
+package org.ops4j.pax.exam.karaf.options;
+
+import org.ops4j.pax.exam.karaf.options.configs.FeaturesCfg;
+
+public class KarafBootFeatureOption extends KarafDistributionConfigurationFileExtendOption {
+
+    public KarafBootFeatureOption(String name) {
+        super(FeaturesCfg.BOOT, name);
+    }
+
+    public KarafBootFeatureOption(String name, String version) {
+        super(FeaturesCfg.BOOT, name + ";version=" + version);
+    }
+}

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafDistributionConfigurationFileOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafDistributionConfigurationFileOption.java
@@ -27,15 +27,25 @@ public abstract class KarafDistributionConfigurationFileOption implements Option
     private String configurationFilePath;
     private String key;
     private String value;
+    private String separator;
 
     public KarafDistributionConfigurationFileOption(ConfigurationPointer pointer, String value) {
-        this(pointer.getConfigurationFilePath(), pointer.getKey(), value);
+        this(pointer.getConfigurationFilePath(), pointer.getKey(), value, null);
+    }
+
+    public KarafDistributionConfigurationFileOption(ConfigurationPointer pointer, String value, String separator) {
+        this(pointer.getConfigurationFilePath(), pointer.getKey(), value, separator);
     }
 
     public KarafDistributionConfigurationFileOption(String configurationFilePath, String key, String value) {
+        this(configurationFilePath, key, value, null);
+    }
+
+    public KarafDistributionConfigurationFileOption(String configurationFilePath, String key, String value, String separator) {
         this.configurationFilePath = configurationFilePath;
         this.key = key;
         this.value = value;
+        this.separator = separator;
     }
 
     public KarafDistributionConfigurationFileOption(String configurationFilePath) {
@@ -52,6 +62,10 @@ public abstract class KarafDistributionConfigurationFileOption implements Option
 
     public String getValue() {
         return value;
+    }
+
+    public String getSeparator() {
+        return separator;
     }
 
 }

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafDistributionOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafDistributionOption.java
@@ -251,11 +251,18 @@ public final class KarafDistributionOption {
     }
 
     /**
+     * Specify given log level for category.
+     */
+    public static Option logCategoryLevel(String category, LogLevel logLevel) {
+        return new LogCategoryLevelOption(category, logLevel);
+    }
+
+    /**
      * A very simple and convinient method to set a specific log level without the need of configure
      * the specific option itself.
      */
     public static LogLevelOption logLevel() {
-        return new LogLevelOption();
+        return new LogLevelOption(LogLevel.WARN);
     }
 
     /**

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafFeatureRepositoryOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafFeatureRepositoryOption.java
@@ -1,0 +1,11 @@
+package org.ops4j.pax.exam.karaf.options;
+
+import org.ops4j.pax.exam.karaf.options.configs.FeaturesCfg;
+
+public class KarafFeatureRepositoryOption extends KarafDistributionConfigurationFileExtendOption {
+
+    public KarafFeatureRepositoryOption(String url) {
+        super(FeaturesCfg.REPOSITORIES, url);
+    }
+
+}

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/LogCategoryLevelOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/LogCategoryLevelOption.java
@@ -1,0 +1,12 @@
+package org.ops4j.pax.exam.karaf.options;
+
+import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
+import org.ops4j.pax.exam.karaf.options.configs.LoggingCfg;
+
+public class LogCategoryLevelOption extends KarafDistributionConfigurationFilePutOption {
+
+    public LogCategoryLevelOption(String category, LogLevel level) {
+        super(LoggingCfg.FILE_PATH, "log4j.logger." + category, level.toString());
+    }
+
+}

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/LogLevelOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/LogLevelOption.java
@@ -16,25 +16,28 @@
  */
 package org.ops4j.pax.exam.karaf.options;
 
-import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.karaf.options.configs.LoggingCfg;
 
 /**
  * While the log-level could also be configured using the config options in the configuration files we also provide a
  * more easy option here.
  */
-public class LogLevelOption implements Option {
+public class LogLevelOption extends KarafDistributionConfigurationFilePutOption {
 
     public static enum LogLevel {
         TRACE, DEBUG, INFO, WARN, ERROR
     }
 
+    public final static String DEFAULT_APPENDERS = "out, stdout, osgi:*";
+
     private LogLevel logLevel;
 
-    public LogLevelOption() {
+    public LogLevelOption(LogLevel level) {
+        this(level, DEFAULT_APPENDERS);
     }
 
-    public LogLevelOption(LogLevel logLevel) {
-        this.logLevel = logLevel;
+    public LogLevelOption(LogLevel level, String appenders) {
+        super(LoggingCfg.ROOT_LOGGER, level + "," + appenders);
     }
 
     public LogLevelOption logLevel(LogLevel _logLevel) {

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/container/karaf/KarafOptionsTest.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/container/karaf/KarafOptionsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ops4j.pax.exam.container.karaf;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logCategoryLevel;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
+import org.osgi.framework.BundleContext;
+
+@RunWith(PaxExam.class)
+public class KarafOptionsTest {
+
+    @Inject
+    private BundleContext bc;
+
+    @Configuration
+    public Option[] config() {
+        return new Option[] {
+            karafDistributionConfiguration()
+                .frameworkUrl(maven("org.apache.karaf", "apache-karaf", "2.3.2").type("zip"))
+                .karafVersion("2.3.2").useDeployFolder(false).unpackDirectory(new File("target/karaf")),
+            configureConsole().ignoreLocalConsole().startRemoteShell(),
+            logLevel(LogLevel.INFO),
+            logCategoryLevel("org.apache.aries", LogLevel.ERROR),
+            logCategoryLevel("org.apache.felix", LogLevel.ERROR),
+        };
+    }
+
+    @Test
+    public void checkKarafSystemService() throws Exception {
+        assertThat(bc, is(notNullValue()));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,31 @@
 
     <profiles>
         <profile>
+            <id>core</id>
+            
+            <modules>
+                <module>build/pax-exam-checkstyle-rules</module>
+                <module>pom</module>
+                <module>core/pax-exam</module>
+                <module>core/pax-exam-spi</module>
+                <module>core/pax-exam-extender-service</module>
+                <module>core/pax-exam-inject</module>
+                <module>core/pax-exam-invoker-junit</module>
+                <module>core/pax-exam-invoker-servlet</module>
+                <module>core/pax-exam-servlet-bridge</module>
+                <module>core/pax-exam-cdi</module>
+                <module>core/pax-exam-spring</module>
+                <module>core/pax-exam-cm</module>
+                <module>core/pax-exam-link-mvn</module>
+                <module>core/pax-exam-link-assembly</module>
+                <module>core/pax-exam-container-rbc</module>
+                <module>core/pax-exam-container-rbc-client</module>
+            </modules>
+
+        </profile>
+
+
+        <profile>
             <id>default</id>
             <activation>
                 <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
Please do not merge this pull request yet.

I've created it as entry point for discussion about Pax Exam options used by Karaf test container. In few places we have commas which are simply separators for properties like boot features, repositories and so on. Because of that in many places we need to keep these "," and have values prepended by it. This causes small, but additional effort in test code.

To avoid string glue for boot features and repositories I prepared additional options:
- **KarafBootFeatureOption**
- **KarafFeatureRepositoryOption**

These options allows to extend bootFeatures and featureRepositories properties in org.apache.karaf.features.cfg file.

Additional option introduced by this commit is **LogCategoryLevelOption** which allows to specify log4j.logger.<category> property inside org.ops4j.pax.logging.cfg.

During my work on these options I've found that lots of options are handled in manual way - ie. each config option has corresponding method in KarafTestContainer. Amount of code duplicated or very similar there is terrifying. If you don't mean, and if you like the approach of unifying option handling, I would like to refactor it a little bit and then merge this pull request.
