### PR TITLE
[PAXEXAM-609] Correct order of acquired locks to avoid possible deadlock

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/runner/InternalRunner.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/runner/InternalRunner.java
@@ -28,7 +28,9 @@ import org.ops4j.io.Pipe;
 public class InternalRunner {
 
     private Process frameworkProcess;
+    private Object frameworkProcessMonitor = new Object();
     private Thread shutdownHook;
+    private final Object shutdownHookMonitor = new Object();
 
     public synchronized void exec(CommandLineBuilder commandLine, final File workingDirectory,
         final String[] envOptions) {
@@ -65,7 +67,7 @@ public class InternalRunner {
     public void shutdown() {
         try {
             if (shutdownHook != null) {
-                synchronized (shutdownHook) {
+                synchronized (shutdownHookMonitor) {
                     if (shutdownHook != null) {
                         Runtime.getRuntime().removeShutdownHook(shutdownHook);
                         frameworkProcess = null;
@@ -85,9 +87,9 @@ public class InternalRunner {
      */
     public void waitForExit() {
         if (shutdownHook != null) {
-            synchronized (shutdownHook) {
+            synchronized (shutdownHookMonitor) {
                 if (shutdownHook != null) {
-                    synchronized (frameworkProcess) {
+                    synchronized (frameworkProcessMonitor) {
                         try {
                             frameworkProcess.waitFor();
                             shutdown();


### PR DESCRIPTION
For detailed analysis, please see: https://issues.apache.org/jira/browse/KARAF-2812
