### PR TITLE
[PAXEXAM-690] Return OSGI 4.0.0 support in pax-exam-container-native

### DIFF
--- a/containers/pax-exam-container-native/src/main/java/org/ops4j/pax/exam/nat/internal/StartLevelAdapter.java
+++ b/containers/pax-exam-container-native/src/main/java/org/ops4j/pax/exam/nat/internal/StartLevelAdapter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 Mario Krizmanić.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam.nat.internal;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
+import org.osgi.service.startlevel.StartLevel;
+
+/**
+ * Adapts {@link FrameworkStartLevel} to match deprecated {@link StartLevel}
+ * interface.
+ * <p>
+ * This adapter is introduced to support backward compatibility with OSGi 4.0.0
+ * version because FrameworkStartLevel appeared in the newer versions.
+ */
+@SuppressWarnings("deprecation")
+public class StartLevelAdapter implements StartLevel {
+
+    private final FrameworkStartLevel startLevel;
+
+    public StartLevelAdapter(FrameworkStartLevel startLevel) {
+        this.startLevel = startLevel;
+    }
+
+    @Override
+    public int getStartLevel() {
+        return startLevel.getStartLevel();
+    }
+
+    @Override
+    public void setStartLevel(int startlevel) {
+        startLevel.setStartLevel(startlevel);
+    }
+
+    @Override
+    public int getBundleStartLevel(Bundle bundle) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setBundleStartLevel(Bundle bundle, int startlevel) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInitialBundleStartLevel() {
+        return startLevel.getInitialBundleStartLevel();
+    }
+
+    @Override
+    public void setInitialBundleStartLevel(int startlevel) {
+        startLevel.setInitialBundleStartLevel(startlevel);
+    }
+
+    @Override
+    public boolean isBundlePersistentlyStarted(Bundle bundle) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isBundleActivationPolicyUsed(Bundle bundle) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/containers/pax-exam-container-native/src/test/java/org/ops4j/pax/exam/nat/internal/StartLevelAdapterTest.java
+++ b/containers/pax-exam-container-native/src/test/java/org/ops4j/pax/exam/nat/internal/StartLevelAdapterTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 Mario Krizmanić.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam.nat.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
+
+/**
+ * Unit tests for the {@link StartLevelAdapter} class.
+ */
+public class StartLevelAdapterTest {
+
+    private FrameworkStartLevel frameworkStartLevel = mock(FrameworkStartLevel.class);
+    private StartLevelAdapter startLevel = new StartLevelAdapter(frameworkStartLevel);
+
+    @Before
+    public void setUp() {
+        reset(frameworkStartLevel);
+    }
+
+    @Test
+    public void testGetStartLevel() {
+        int startLevelToReturn = 10;
+
+        when(frameworkStartLevel.getStartLevel()).thenReturn(startLevelToReturn);
+
+        int actualStartLevel = startLevel.getStartLevel();
+
+        verify(frameworkStartLevel).getStartLevel();
+        assertEquals(startLevelToReturn, actualStartLevel);
+    }
+
+    @Test
+    public void testSetStartLevel() {
+        int startLevelToSet = 6;
+
+        startLevel.setStartLevel(startLevelToSet);
+
+        verify(frameworkStartLevel).setStartLevel(startLevelToSet);;
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetBundleStartLevel() {
+        startLevel.getBundleStartLevel(mock(Bundle.class));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetBundleStartLevel() {
+        int startLevelToSet = 6;
+
+        startLevel.setBundleStartLevel(mock(Bundle.class), startLevelToSet);
+    }
+
+    @Test
+    public void testGetInitialBundleStartLevel() {
+        int initialBundleStartLevel = 4;
+
+        when(frameworkStartLevel.getInitialBundleStartLevel()).thenReturn(initialBundleStartLevel);
+
+        int actualBundleStartLevel = startLevel.getInitialBundleStartLevel();
+
+        verify(frameworkStartLevel).getInitialBundleStartLevel();
+        assertEquals(initialBundleStartLevel, actualBundleStartLevel);
+    }
+
+    @Test
+    public void testSetInitialBundleStartLevel() {
+        int startLevelToSet = 11;
+
+        startLevel.setInitialBundleStartLevel(startLevelToSet);
+
+        verify(frameworkStartLevel).setInitialBundleStartLevel(startLevelToSet);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsBundlePersistentlyStarted() {
+        startLevel.isBundlePersistentlyStarted(mock(Bundle.class));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIsBundleActivationPolicyUsed() {
+        startLevel.isBundleActivationPolicyUsed(mock(Bundle.class));
+    }
+}

--- a/core/pax-exam-extender-service/osgi.bnd
+++ b/core/pax-exam-extender-service/osgi.bnd
@@ -9,7 +9,10 @@ Bundle-SymbolicName:\
 
 Export-Package: org.ops4j.pax.exam.raw.extender
 
-Import-Package: org.slf4j;version="[1.4,2)", *
+Import-Package:\
+  org.osgi.framework;version="[1.5,2)",\
+  org.slf4j;version="[1.4,2)",\
+  *
 
 Private-Package:\
   ${bundle.namespace}.*

--- a/core/pax-exam-inject/osgi.bnd
+++ b/core/pax-exam-inject/osgi.bnd
@@ -11,6 +11,7 @@ Private-Package:\
   ${bundle.namespace}.*
 
 Import-Package:\
-  !${bundle.namespace}, org.slf4j;version="[1.4,2)", *
-  
-  
+  !${bundle.namespace},\
+  org.osgi.framework;version="[1.5,2)",\
+  org.slf4j;version="[1.4,2)",\
+  *

--- a/core/pax-exam-invoker-junit/osgi.bnd
+++ b/core/pax-exam-invoker-junit/osgi.bnd
@@ -11,6 +11,7 @@ Private-Package:\
   ${bundle.namespace}.*
 
 Import-Package:\
-  !${bundle.namespace}, org.slf4j;version="[1.4,2)", *
-  
-  
+  !${bundle.namespace},\
+  org.osgi.framework;version="[1.5,2)",\
+  org.slf4j;version="[1.4,2)",\
+  *

--- a/itest/osgi/pom.xml
+++ b/itest/osgi/pom.xml
@@ -72,16 +72,29 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>equinox-native</id>
+                                <id>equinox-3.6-native</id>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
                                     <profiles>
-                                        <profile>equinox</profile>
+                                        <profile>equinox-3.6</profile>
                                         <profile>native</profile>
                                     </profiles>
-                                    <cloneProjectsTo>${project.build.directory}/equinox-native</cloneProjectsTo>
+                                    <cloneProjectsTo>${project.build.directory}/equinox-3.6-native</cloneProjectsTo>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>equinox-3.7-native</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <profiles>
+                                        <profile>equinox-3.7</profile>
+                                        <profile>native</profile>
+                                    </profiles>
+                                    <cloneProjectsTo>${project.build.directory}/equinox-3.7-native</cloneProjectsTo>
                                 </configuration>
                             </execution>
                             <execution>
@@ -114,16 +127,29 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>equinox-forked</id>
+                                <id>equinox-3.6-forked</id>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
                                     <profiles>
-                                        <profile>equinox</profile>
+                                        <profile>equinox-3.6</profile>
                                         <profile>forked</profile>
                                     </profiles>
-                                    <cloneProjectsTo>${project.build.directory}/equinox-forked</cloneProjectsTo>
+                                    <cloneProjectsTo>${project.build.directory}/equinox-3.6-forked</cloneProjectsTo>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>equinox-3.7-forked</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <profiles>
+                                        <profile>equinox-3.7</profile>
+                                        <profile>forked</profile>
+                                    </profiles>
+                                    <cloneProjectsTo>${project.build.directory}/equinox-3.7-forked</cloneProjectsTo>
                                 </configuration>
                             </execution>
                             <execution>

--- a/itest/osgi/src/it/regression-multi/pom.xml
+++ b/itest/osgi/src/it/regression-multi/pom.xml
@@ -29,6 +29,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam.samples</groupId>
+            <artifactId>pax-exam-sample11-wab</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam.samples</groupId>

--- a/itest/osgi/src/it/regression-multi/src/test/java/org/ops4j/pax/exam/regression/multi/server/ClassRuleExternalConfigurationTest.java
+++ b/itest/osgi/src/it/regression-multi/src/test/java/org/ops4j/pax/exam/regression/multi/server/ClassRuleExternalConfigurationTest.java
@@ -50,7 +50,7 @@ public class ClassRuleExternalConfigurationTest {
         Client client = ClientBuilder.newClient();
         WebTarget resource = client.target(url);
         String response = resource.request().get(String.class);
-        assertThat(response, containsString("wab symbolic name : wab-sample"));
+        assertThat(response, containsString("wab symbolic name : org.ops4j.pax.exam.samples.pax-exam-sample11-wab"));
     }
 
     @Test
@@ -58,6 +58,7 @@ public class ClassRuleExternalConfigurationTest {
         Client client = ClientBuilder.newClient();
         WebTarget resource = client.target(url);
         String response = resource.request().get(String.class);
-        assertThat(response, containsString("wab version :3.0.0"));
+        assertThat(response, containsString("wab version :"));
+        // TODO check version
     }
 }

--- a/itest/osgi/src/it/regression-multi/src/test/java/org/ops4j/pax/exam/regression/multi/server/ExternalConfigurationTest.java
+++ b/itest/osgi/src/it/regression-multi/src/test/java/org/ops4j/pax/exam/regression/multi/server/ExternalConfigurationTest.java
@@ -51,7 +51,7 @@ public class ExternalConfigurationTest {
         Client client = ClientBuilder.newClient();
         WebTarget resource = client.target(url);
         String response = resource.request().get(String.class);
-        assertThat(response, containsString("wab symbolic name : wab-sample"));
+        assertThat(response, containsString("wab symbolic name : org.ops4j.pax.exam.samples.pax-exam-sample11-wab"));
     }
 
     @Test
@@ -59,6 +59,7 @@ public class ExternalConfigurationTest {
         Client client = ClientBuilder.newClient();
         WebTarget resource = client.target(url);
         String response = resource.request().get(String.class);
-        assertThat(response, containsString("wab version :3.0.0"));
+        assertThat(response, containsString("wab version :"));
+        // TODO check version
     }
 }

--- a/itest/osgi/src/it/regression-multi/src/test/java/org/ops4j/pax/exam/regression/multi/server/WabSampleConfiguration.java
+++ b/itest/osgi/src/it/regression-multi/src/test/java/org/ops4j/pax/exam/regression/multi/server/WabSampleConfiguration.java
@@ -54,6 +54,6 @@ public class WabSampleConfiguration {
             mavenBundle("org.slf4j", "slf4j-api", "1.6.4"),
             mavenBundle("org.slf4j", "slf4j-simple", "1.6.4").noStart(),
 
-            mavenBundle("org.apache.geronimo.samples.osgi", "wab-sample", "3.0.0"));
+            mavenBundle("org.ops4j.pax.exam.samples", "pax-exam-sample11-wab").versionAsInProject());
     }
 }

--- a/itest/osgi/src/it/regression-multi/src/test/java/org/ops4j/pax/exam/regression/multi/server/WabSampleTest.java
+++ b/itest/osgi/src/it/regression-multi/src/test/java/org/ops4j/pax/exam/regression/multi/server/WabSampleTest.java
@@ -70,7 +70,7 @@ public class WabSampleTest {
             mavenBundle("org.slf4j", "slf4j-api", "1.6.4"),
             mavenBundle("org.slf4j", "slf4j-simple", "1.6.4").noStart(),
 
-            mavenBundle("org.apache.geronimo.samples.osgi", "wab-sample", "3.0.0")
+            mavenBundle("org.ops4j.pax.exam.samples", "pax-exam-sample11-wab").versionAsInProject()
 
         );
     }
@@ -82,6 +82,6 @@ public class WabSampleTest {
         String url = String.format("http://localhost:%s/wab/WABServlet", port);
         WebTarget resource = client.target(url);
         String response = resource.request().get(String.class);
-        assertThat(response, containsString("wab symbolic name : wab-sample"));
+        assertThat(response, containsString("wab symbolic name : org.ops4j.pax.exam.samples.pax-exam-sample11-wab"));
     }
 }

--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -693,7 +693,7 @@
             </dependencies>
         </profile>
         <profile>
-            <id>equinox</id>
+            <id>equinox-3.6</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
                 <property>
@@ -708,6 +708,28 @@
                 <dependency>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>org.eclipse.osgi</artifactId>
+                    <version>3.6.2.R36x_v20110210</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>equinox-3.7</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>pax.exam.framework</name>
+                    <value>equinox</value>
+                </property>
+            </activation>
+            <properties>
+                <pax.exam.framework>equinox</pax.exam.framework>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>org.eclipse.osgi</artifactId>
+                    <version>3.7.0.v20110613</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/samples/pax-exam-sample11-wab/pom.xml
+++ b/samples/pax-exam-sample11-wab/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-samples</artifactId>
+        <version>4.5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.ops4j.pax.exam.samples</groupId>
+    <artifactId>pax-exam-sample11-wab</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>OPS4J Pax Exam Sample11 Wab Module</name>
+
+    <description>
+        Inlines Apache Geronimo's wab-sample module in order to define wide range of
+        imported org.osgi.framework package versions. Wab-sample module imports
+        only 1.6 version of the package so it is not adequate for integration tests
+        in various OSGi versions.
+    </description>
+
+    <properties>
+        <bundle.symbolicName>org.ops4j.pax.exam.sample11.wab</bundle.symbolicName>
+        <bundle.namespace>org.ops4j.pax.exam.sample11.wab</bundle.namespace>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Embed-Dependency>wab-sample;inline=true</Embed-Dependency>
+                        <Import-Package>org.osgi.framework;version="[1.5,2)",*</Import-Package>
+                        <Web-ContextPath>/wab</Web-ContextPath>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.geronimo.samples.osgi</groupId>
+            <artifactId>wab-sample</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -30,6 +30,7 @@
     <module>pax-exam-sample8-ds</module>
     <module>pax-exam-sample9-pde</module>
     <module>pax-exam-sample10-derby</module>
+    <module>pax-exam-sample11-wab</module>
     <module>exam-itest-sample-karaf</module>
   </modules>
 </project>


### PR DESCRIPTION
This patch includes API adapters between OSGI 4.0.0 and newer OSGI
versions and integration tests.