### PR TITLE
NativeTestContainer: adjustable timeout for the ProbeInvoker service

### DIFF
--- a/containers/pax-exam-container-native/src/main/java/org/ops4j/pax/exam/nat/internal/NativeTestContainer.java
+++ b/containers/pax-exam-container-native/src/main/java/org/ops4j/pax/exam/nat/internal/NativeTestContainer.java
@@ -52,6 +52,7 @@ import org.ops4j.pax.exam.TestContainerException;
 import org.ops4j.pax.exam.options.BootDelegationOption;
 import org.ops4j.pax.exam.options.FrameworkPropertyOption;
 import org.ops4j.pax.exam.options.FrameworkStartLevelOption;
+import org.ops4j.pax.exam.options.ProbeInvokerTimeoutOption;
 import org.ops4j.pax.exam.options.ProvisionOption;
 import org.ops4j.pax.exam.options.SystemPackageOption;
 import org.ops4j.pax.exam.options.SystemPropertyOption;
@@ -104,8 +105,17 @@ public class NativeTestContainer implements TestContainer {
         Map<String, String> props = new HashMap<String, String>();
         props.put(PROBE_SIGNATURE_KEY, address.root().identifier());
         BundleContext bundleContext = framework.getBundleContext();
-        ProbeInvoker probeInvokerService = ServiceLookup.getService(bundleContext,
-            ProbeInvoker.class, props);
+
+        ProbeInvoker probeInvokerService;
+        ProbeInvokerTimeoutOption probeInvokerTimeoutOption = system
+                .getSingleOption(ProbeInvokerTimeoutOption.class);
+        if (probeInvokerTimeoutOption != null) {
+            long timeout = probeInvokerTimeoutOption.getTimeout();
+            probeInvokerService = ServiceLookup.getService(bundleContext, ProbeInvoker.class, timeout, props);
+        }
+        else {
+            probeInvokerService = ServiceLookup.getService(bundleContext, ProbeInvoker.class, props);
+        }
         probeInvokerService.call(address.arguments());
     }
 

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/CoreOptions.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/CoreOptions.java
@@ -39,6 +39,7 @@ import org.ops4j.pax.exam.options.MavenArtifactDeploymentOption;
 import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.OptionalCompositeOption;
+import org.ops4j.pax.exam.options.ProbeInvokerTimeoutOption;
 import org.ops4j.pax.exam.options.PropagateSystemPropertyOption;
 import org.ops4j.pax.exam.options.ProvisionOption;
 import org.ops4j.pax.exam.options.ServerModeOption;
@@ -884,5 +885,16 @@ public class CoreOptions {
      */
     public static UrlProvisionOption linkBundle(String symbolicName) {
         return bundle(String.format("link:classpath:%s.link", symbolicName));
+    }
+
+    /**
+     * Creates an option to set the timeout for the service lookup of the ProbeInvoker.
+     *
+     * @param timeoutInMillis
+     *            timeout in milliseconds to wait for services to appear
+     * @return ProbeInvokerOption ProbeInvoker timeout option
+     */
+    public static ProbeInvokerTimeoutOption probeInvokerTimeout(long timeoutInMillis) {
+        return new ProbeInvokerTimeoutOption(timeoutInMillis);
     }
 }

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/options/ProbeInvokerTimeoutOption.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/options/ProbeInvokerTimeoutOption.java
@@ -1,0 +1,74 @@
+package org.ops4j.pax.exam.options;
+
+import org.ops4j.pax.exam.Option;
+
+/**
+ * Option specifying the timeout the ProbeInvoker waits for
+ * services to appear.
+ * 
+ * @author Fabian Bongratz, Konstantin Matuschek (Matuschek.ObjectVision@partner.akdb.de)
+ * @since 4.6.0, August 11, 2015
+ */
+
+public class ProbeInvokerTimeoutOption implements Option {
+
+    private final long timeout;
+
+    /**
+     * Constructor.
+     * 
+     * @param timeoutInMillis
+     *            timeout for ProbeInvoker (must be bigger then zero)
+     * 
+     * @throws IllegalArgumentException
+     *             - If timoutInMillis is &lt;= 0
+     */
+    public ProbeInvokerTimeoutOption(long timeoutInMillis) {
+        if (timeoutInMillis < 0) {
+            throw new IllegalArgumentException("Timeout must be zero or greater, found: " + timeoutInMillis);
+        }
+        this.timeout = timeoutInMillis;
+    }
+
+    /**
+     * Getter.
+     * 
+     * @return timeout in Milliseconds (never negative)
+     */
+    public long getTimeout() {
+        return this.timeout;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return new StringBuilder().append(FrameworkStartLevelOption.class.getSimpleName())
+            .append("{timeout='").append(timeout).append("\'}").toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int)timeout;
+        return result;
+    }
+
+    // CHECKSTYLE:OFF : generated code    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ProbeInvokerTimeoutOption other = (ProbeInvokerTimeoutOption) obj;
+        if (timeout != other.timeout)
+            return false;
+        return true;
+    }
+    // CHECKSTYLE:ON
+}


### PR DESCRIPTION
Make it possible to adjust the timeout the NativeTestContainer waits for the ProbeInvoker service via a new, optional ProbeInvokerTimeoutOption.

Also see https://ops4j1.jira.com/browse/PAXEXAM-733 for details.