### PR TITLE
[PAXEXAM-753] add cause to exception

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafPropertiesFile.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafPropertiesFile.java
@@ -71,7 +71,7 @@ public class KarafPropertiesFile {
             FileUtils.copyFile(source, propertyFile);
         } 
         catch (IOException e) {
-            throw new IllegalStateException("It is required to replace propertyFile");
+            throw new IllegalStateException("It is required to replace propertyFile", e);
         }
     }
 


### PR DESCRIPTION
make the exception more precise e.g. if file could not be found