### PR TITLE
PAXEXAM-674 Configurations and probe builders do not need to be static

### DIFF
--- a/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedFrameworkMethod.java
+++ b/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedFrameworkMethod.java
@@ -22,9 +22,9 @@ import org.ops4j.pax.exam.TestAddress;
 /**
  * Decorates a framework method with a parameter index. Used for parameterized tests
  * with {@code PaxExamParameterized}.
- * 
+ *
  * @author Harald Wellmann
- * 
+ *
  */
 class ParameterizedFrameworkMethod extends DecoratedFrameworkMethod {
 
@@ -34,6 +34,16 @@ class ParameterizedFrameworkMethod extends DecoratedFrameworkMethod {
 
     @Override
     public String getName() {
-        return String.format("%s[%d]", frameworkMethod.getName(), address.arguments()[0]);
+
+    	// arg[0] must be an integer (at least, for the JUnit runner).
+    	// The customized (parameterized) name is given as a second argument.
+
+    	String result;
+    	if( this.address.arguments().length > 1 )
+    		result = String.format("%s", this.address.arguments()[1]);
+    	else
+    		result = String.format("%s[%d]", this.frameworkMethod.getName(), this.address.arguments()[0]);
+
+        return result;
     }
 }


### PR DESCRIPTION
By default, JUnit parameterized tests with PAX Exam need static methods for configuration and probe builders. Notice that this is not mentioned in the documentation. When these methods are not static, you get a NullPointerException, as mentioned in [PAXEXAM-674](https://ops4j1.jira.com/browse/PAXEXAM-674).

This patch allows to use non-static methods for configurations and probe builders.
The test class is instantiated with every configuration. And every test class instance comes with its own OSGi configuration.

This was tested with parameterized tests on Apache Karaf 4.0.2.
This patch also comes with support of custom names for parameterized tests (the name attribute of the *Parameters* annotation).

I asked for some feedback on JIRA, but nothing yet.
I hope more will come with this PR.