### PR TITLE
Fix port conflict issue in container startup

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
@@ -109,6 +109,7 @@ public class KarafTestContainer implements TestContainer {
     private File targetFolder;
 
     private Registry rgstry;
+    private FreePort freePort;
 
     public KarafTestContainer(ExamSystem system,
         KarafDistributionBaseConfigurationOption framework, Runner runner) {
@@ -125,7 +126,7 @@ public class KarafTestContainer implements TestContainer {
             Option invokerConfiguration = getInvokerConfiguration();
 
             //registry.selectGracefully();
-            FreePort freePort = new FreePort(21000, 21099);
+            freePort = new FreePort(21000, 21099);
             int port = freePort.getPort();
             LOGGER.debug("using RMI registry at port {}", port);
             rgstry = LocateRegistry.createRegistry(port);
@@ -551,6 +552,11 @@ public class KarafTestContainer implements TestContainer {
             }
         }
         finally {
+            try {
+                freePort.close();
+            } catch (Exception e) {
+                LOGGER.warn("Closing port threw an exception. It is likely already closed", e);
+            }
             started = false;
             target = null;
             if (shouldDeleteRuntime()) {


### PR DESCRIPTION
I'm trying to run integration tests in parallel and it seems that since the Karaf Containers come up at essentially the same time, they both get assigned to the same port and then I get conflicts. These changes just make sure the port is then closed during the end of the test. This PR is associated with https://github.com/ops4j/org.ops4j.base/pull/1

Edit: This PR will fail tests on a compilation error due to changes to FreePort in my other PR.