### PR TITLE
Allow a delay for a service to be present in the remote test container before installing the test probe

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
@@ -233,6 +233,16 @@ public class KarafTestContainer implements TestContainer {
         else {
             LOGGER
                 .info("System runs in Server Mode. Which means, no Test facility bundles available on target system.");
+        for (WaitForServiceOption waitForServiceOption : subsystem.getOptions(WaitForServiceOption.class)) {
+            LOGGER.info("Waiting for service {}, timeout:[{}]", waitForServiceOption.getServiceClassName(), waitForServiceOption.getTimeout().toString());
+            try {
+                waitForService(waitForServiceOption.getServiceClassName(), waitForServiceOption.getTimeout());
+                LOGGER.info("Service {} has been found in the test container", waitForServiceOption.getServiceClassName());
+            } catch (NoSuchServiceException e) {
+                LOGGER.error("Service {} could not be found in the test container", waitForServiceOption.getServiceClassName());
+            } catch (RemoteException e) {
+                LOGGER.error("Error waiting for service {} in the test container: {}", waitForServiceOption.getServiceClassName(), e.toString());
+            }
         }
     }
 
@@ -578,6 +588,10 @@ public class KarafTestContainer implements TestContainer {
 
     private void waitForState(final long bundleId, final int state, final RelativeTimeout timeout) {
         target.getClientRBC().waitForState(bundleId, state, timeout);
+    }
+
+    private void waitForService(String serviceClassName, final RelativeTimeout timeout) throws NoSuchServiceException, RemoteException {
+        target.getClientRBC().waitForService(serviceClassName, timeout);
     }
 
     @Override

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafDistributionOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafDistributionOption.java
@@ -65,6 +65,10 @@ public final class KarafDistributionOption {
         return new KarafExamSystemConfigurationOption(invoker);
     }
 
+    public static Option waitForServiceOption(String serviceClassName, long timeout){
+        return new WaitForServiceOption(serviceClassName, timeout);
+    }
+
     /**
      * The karaf pax-logging configuration is typically not a file manipulated very often. Therefore
      * we take the freedom of adding a console logger and changing the log level directly. IF you

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/WaitForServiceOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/WaitForServiceOption.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam.karaf.options;
+
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.RelativeTimeout;
+
+/**
+ * Per default the folder pax-exam is deleting the test directories after a test is over. If you want to keep those
+ * directories (for later evaluation) simply set this option.
+ */
+public class WaitForServiceOption implements Option {
+    final private String serviceClassName;
+
+    final private RelativeTimeout timeout;
+
+    public WaitForServiceOption(String serviceClassName, long timeout) {
+        this.serviceClassName = serviceClassName;
+        this.timeout = new RelativeTimeout(timeout);
+    }
+
+    public String getServiceClassName() {
+        return serviceClassName;
+    }
+
+    public RelativeTimeout getTimeout() {
+        return timeout;
+    }
+}

--- a/core/pax-exam-container-rbc-client/src/main/java/org/ops4j/pax/exam/rbc/client/RemoteBundleContextClient.java
+++ b/core/pax-exam-container-rbc-client/src/main/java/org/ops4j/pax/exam/rbc/client/RemoteBundleContextClient.java
@@ -17,11 +17,13 @@
  */
 package org.ops4j.pax.exam.rbc.client;
 
-import java.io.InputStream;
-
 import org.ops4j.pax.exam.RelativeTimeout;
 import org.ops4j.pax.exam.TestAddress;
+import org.ops4j.pax.exam.rbc.internal.NoSuchServiceException;
 import org.ops4j.pax.exam.rbc.internal.RemoteBundleContext;
+
+import java.io.InputStream;
+import java.rmi.RemoteException;
 
 /**
  * A {@link RemoteBundleContext} client, that takes away RMI handling.
@@ -45,6 +47,8 @@ public interface RemoteBundleContextClient {
     void stop();
 
     void waitForState(final long bundleId, final int state, final RelativeTimeout timeout);
+
+    void waitForService(String serviceClassName, RelativeTimeout timeout) throws NoSuchServiceException, RemoteException;
 
     void call(TestAddress address);
 }

--- a/core/pax-exam-container-rbc-client/src/main/java/org/ops4j/pax/exam/rbc/client/intern/RemoteBundleContextClientImpl.java
+++ b/core/pax-exam-container-rbc-client/src/main/java/org/ops4j/pax/exam/rbc/client/intern/RemoteBundleContextClientImpl.java
@@ -218,6 +218,11 @@ public class RemoteBundleContextClientImpl implements RemoteBundleContextClient 
         }
     }
 
+    @Override
+    public void waitForService(String serviceClassName, RelativeTimeout timeout) throws NoSuchServiceException, RemoteException {
+        getRemoteBundleContext().waitForService(serviceClassName, null, timeout);
+    }
+
     /**
      * Looks up the {@link RemoteBundleContext} via RMI. The lookup will timeout in the specified
      * number of millis.

--- a/core/pax-exam-container-rbc/src/main/java/org/ops4j/pax/exam/rbc/internal/RemoteBundleContext.java
+++ b/core/pax-exam-container-rbc/src/main/java/org/ops4j/pax/exam/rbc/internal/RemoteBundleContext.java
@@ -75,6 +75,8 @@ public interface RemoteBundleContext extends Remote {
         NoSuchServiceException, NoSuchMethodException, IllegalAccessException,
         InvocationTargetException;
 
+    void waitForService(final String serviceClassName, final String filter, final RelativeTimeout timeout) throws NoSuchServiceException, RemoteException;
+
     /**
      * Installs a bundle remotly.
      * 

--- a/core/pax-exam-container-rbc/src/main/java/org/ops4j/pax/exam/rbc/internal/RemoteBundleContextImpl.java
+++ b/core/pax-exam-container-rbc/src/main/java/org/ops4j/pax/exam/rbc/internal/RemoteBundleContextImpl.java
@@ -80,6 +80,12 @@ public class RemoteBundleContextImpl implements RemoteBundleContext, Serializabl
         return serviceType.getMethod(methodName, methodParams).invoke(service, actualParams);
     }
 
+    @Override
+    public void waitForService(String serviceClassName, String filter, RelativeTimeout timeout) throws NoSuchServiceException, RemoteException {
+        LOG.trace("Retrieving service of [" + serviceClassName + "]");
+        ServiceLookup.getService(bundleContext, serviceClassName, timeout.getValue(), filter);
+    }
+
     public long installBundle(final String bundleUrl) throws BundleException {
         LOG.trace("Install bundle from URL [" + bundleUrl + "]");
         return bundleContext.installBundle(bundleUrl).getBundleId();


### PR DESCRIPTION
This modification can allow specific scenarios where a specialized
service is registered to indicate that the framework is ready for the
test. This can be especially useful for tests using blueprint or test
using bundles that load other bundles in the container without being
explicitely in the boot features defined by the pax exam test.