### PR TITLE
PAXEXAM-804 Add process environment option to Pax Exam

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
@@ -82,6 +82,7 @@ import org.ops4j.pax.exam.options.PropagateSystemPropertyOption;
 import org.ops4j.pax.exam.options.ServerModeOption;
 import org.ops4j.pax.exam.options.SystemPackageOption;
 import org.ops4j.pax.exam.options.SystemPropertyOption;
+import org.ops4j.pax.exam.options.extra.EnvironmentOption;
 import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.exam.rbc.client.RemoteBundleContextClient;
 import org.osgi.framework.Bundle;
@@ -204,7 +205,11 @@ public class KarafTestContainer implements TestContainer {
         File javaHome = new File(System.getProperty("java.home"));
         String main = framework.getKarafMain();
         String options = "";
-        String[] environment = new String[] {};
+        List<String> environment = new ArrayList<>();
+        EnvironmentOption[] environmentOptions = subsystem.getOptions(EnvironmentOption.class);
+        for (EnvironmentOption environmentOption : environmentOptions) {
+            environment.add(environmentOption.getEnvironment());
+        }
         ArrayList<String> javaOpts = new ArrayList<String>();
         appendVmSettingsFromSystem(javaOpts, subsystem);
         String[] javaEndorsedDirs = null;
@@ -221,7 +226,8 @@ public class KarafTestContainer implements TestContainer {
             + shouldRemoteShellBeStarted(subsystem));
         boolean enableMBeanServerBuilder = shouldMBeanServerBuilderBeEnabled(subsystem);
         String[] karafOpts = new String[] {};
-        runner.exec(environment, karafBase, javaHome.toString(), javaOpts.toArray(new String[] {}),
+        String[] env = environment.toArray(new String[environment.size()]);
+        runner.exec(env, karafBase, javaHome.toString(), javaOpts.toArray(new String[] {}),
             javaEndorsedDirs, javaExtDirs, karafHome.toString(), karafData.toString(), karafEtc.toString(),
             karafOpts, opts.toArray(new String[] {}), classPath, main, options,
             enableMBeanServerBuilder);

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/CoreOptions.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/CoreOptions.java
@@ -51,6 +51,7 @@ import org.ops4j.pax.exam.options.UrlReference;
 import org.ops4j.pax.exam.options.WarProbeOption;
 import org.ops4j.pax.exam.options.WrappedUrlProvisionOption;
 import org.ops4j.pax.exam.options.extra.CleanCachesOption;
+import org.ops4j.pax.exam.options.extra.EnvironmentOption;
 import org.ops4j.pax.exam.options.extra.RepositoryOption;
 import org.ops4j.pax.exam.options.extra.RepositoryOptionImpl;
 import org.ops4j.pax.exam.options.extra.VMOption;
@@ -884,5 +885,49 @@ public class CoreOptions {
      */
     public static UrlProvisionOption linkBundle(String symbolicName) {
         return bundle(String.format("link:classpath:%s.link", symbolicName));
+    }
+
+    /**
+     * Creates a composite option of {@link EnvironmentOption}s.
+     *
+     * @param environmentVariables
+     *            process environment variables (cannot be null or containing null entries)
+     *
+     * @return composite option of environment variables
+     *
+     * @throws IllegalArgumentException
+     *             - If environmentVariables array is null or contains null entries
+     */
+    public static Option environment(final String... environmentVariables) {
+        validateNotEmptyContent(environmentVariables, true, "Environment variable options");
+        final List<EnvironmentOption> options = new ArrayList<EnvironmentOption>();
+        for (String environmentVariable : environmentVariables) {
+            options.add(environment(environmentVariable));
+        }
+        return environment(options.toArray(new EnvironmentOption[options.size()]));
+    }
+
+    /**
+     * Creates a composite option of {@link EnvironmentOption}s.
+     *
+     * @param environmentOptions
+     *            process environment variable options
+     *
+     * @return composite option of process environment variable options
+     */
+    public static Option environment(final EnvironmentOption... environmentOptions) {
+        return new DefaultCompositeOption(environmentOptions);
+    }
+
+    /**
+     * Creates a {@link EnvironmentOption}.
+     *
+     * @param environmentVariable
+     *            process environment variable
+     *
+     * @return process environment variable option
+     */
+    public static EnvironmentOption environment(final String environmentVariable) {
+        return new EnvironmentOption(environmentVariable);
     }
 }

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/options/extra/EnvironmentOption.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/options/extra/EnvironmentOption.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Zoran Regvart
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam.options.extra;
+
+import org.ops4j.pax.exam.Option;
+
+import static org.ops4j.lang.NullArgumentException.validateNotEmpty;
+
+/**
+ * Specify process environment.
+ */
+public final class EnvironmentOption implements Option {
+
+    /**
+     * Process environment option. Cannot be null or empty.
+     */
+    private final String environment;
+
+    /**
+     * Creates new {@link EnvironmentOption}.
+     *
+     * @param environment
+     *            process environment option (cannot be null or empty)
+     *
+     * @throws IllegalArgumentException
+     *             - If environment is null or empty
+     */
+    public EnvironmentOption(final String environment) {
+        validateNotEmpty(environment, true, "Environment option");
+        this.environment = environment;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("EnvironmentOption");
+        sb.append("{environment='").append(environment).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/itest/karaf/src/it/regression-karaf/src/test/java/org/ops4j/pax/exam/regression/karaf/EnvironmentOptionTest.java
+++ b/itest/karaf/src/it/regression-karaf/src/test/java/org/ops4j/pax/exam/regression/karaf/EnvironmentOptionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ops4j.pax.exam.regression.karaf;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.extra.EnvironmentOption;
+import org.ops4j.pax.exam.options.extra.VMOption;
+
+@RunWith(PaxExam.class)
+public class EnvironmentOptionTest {
+
+    @Configuration
+    public Option[] config() {
+        return new Option[]{
+                RegressionConfiguration.regressionDefaults(),
+                    new EnvironmentOption("TEST=Option") };
+    }
+
+    @Test
+    public void test() throws Exception {
+        assertEquals("Option", System.getenv("TEST"));
+    }
+}

--- a/itest/karaf/src/it/regression-karaf/src/test/java/org/ops4j/pax/exam/regression/karaf/EnvironmentOptionTest.java
+++ b/itest/karaf/src/it/regression-karaf/src/test/java/org/ops4j/pax/exam/regression/karaf/EnvironmentOptionTest.java
@@ -1,20 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2016 Zoran Regvart
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ops4j.pax.exam.regression.karaf;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This commit adds option to Pax Exam to add process environment variables
to the contaner. Implemented for Karaf only.