### PR TITLE
Cannot found jar file on windows : use separtor in system insteadof '/'

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/runner/KarafEmbeddedRunner.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/runner/KarafEmbeddedRunner.java
@@ -115,7 +115,7 @@ public class KarafEmbeddedRunner implements Runner {
                         mainBundles.addAll(searchMainBundle(file.listFiles()));
                     } 
                     else {
-                        if (file.getPath().contains("/boot")) {
+                        if (file.getPath().contains(File.separator+ "boot")) {
                             // karaf 4.x
                             mainBundles.add(file);
                         } 


### PR DESCRIPTION
When I test karaf in enbeded mode, KarafEmbeddedRunner cannot find main libs.
Can you approve this path ?