### PR TITLE
[PAXEXAM-740] Fix NoRouteToHostException RMI issue for Karaf

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
@@ -128,13 +128,15 @@ public class KarafTestContainer implements TestContainer {
             //registry.selectGracefully();
             FreePort freePort = new FreePort(21000, 21099);
             int port = freePort.getPort();
-            LOGGER.debug("using RMI registry at port {}", port);
-            rgstry = LocateRegistry.createRegistry(port);
 
-            String host = InetAddress.getLocalHost().getHostName();
+            String host = InetAddress.getLoopbackAddress().getHostAddress();
+            LOGGER.info("Creating RMI registry server on {}:{}", host, port);
+            System.setProperty("java.rmi.server.hostname", host);
+            rgstry = LocateRegistry.createRegistry(port);
 
             ExamSystem subsystem = system
                 .fork(options(
+                    systemProperty("java.rmi.server.hostname").value(host),
                     systemProperty(RMI_HOST_PROPERTY).value(host),
                     systemProperty(RMI_PORT_PROPERTY).value(Integer.toString(port)),
                     systemProperty(RMI_NAME_PROPERTY).value(name),

--- a/core/pax-exam-container-rbc-client/src/main/java/org/ops4j/pax/exam/rbc/client/intern/RemoteBundleContextClientImpl.java
+++ b/core/pax-exam-container-rbc-client/src/main/java/org/ops4j/pax/exam/rbc/client/intern/RemoteBundleContextClientImpl.java
@@ -245,8 +245,7 @@ public class RemoteBundleContextClientImpl implements RemoteBundleContextClient 
 
             do {
                 try {
-                    Registry reg = LocateRegistry.getRegistry(registry);
-                    remoteBundleContext = (RemoteBundleContext) reg.lookup(name);
+                    remoteBundleContext = (RemoteBundleContext) getRegistry(registry).lookup(name);
                 }
                 catch (RemoteException e) {
                     reason = e;
@@ -266,6 +265,21 @@ public class RemoteBundleContextClientImpl implements RemoteBundleContextClient 
         }
         return remoteBundleContext;
 
+    }
+
+    // TODO This utility is copy/pasted in pax-exam-container-forked's
+    // ForkedFrameworkFactory, and ideally perhaps should be be put into a
+    // shared utility module
+    private Registry getRegistry(int port) throws RemoteException {
+        Registry reg;
+        String hostName = System.getProperty("java.rmi.server.hostname");
+        if (hostName != null && !hostName.isEmpty()) {
+            reg = LocateRegistry.getRegistry(hostName, port);
+        }
+        else {
+            reg = LocateRegistry.getRegistry(port);
+        }
+        return reg;
     }
 
     @Override


### PR DESCRIPTION
this appears e.g. on Fedora Linux on a laptop with two network adapters
(WiFi and wired Ethernet), if the hostname is not listed in /etc/hosts,
due to use of LocateRegistry -> InetAddress.getLocalHost(), but can also
occcur under other network configurations.

This change fixes the problem in pax-exam-container-karaf.  For
pax-exam-container-forked, another change in Pax Swissbox is required
(coming up next).

see also
http://blog2.vorburger.ch/2017/04/java-local-rmi-using-jdks-inetaddress.html
for more background, and
https://bugs.opendaylight.org/show_bug.cgi?id=8176 for original error.