### PR TITLE
[PAXEXAM-740] Fix NoRouteToHostException RMI issue for forked

### DIFF
--- a/containers/pax-exam-container-forked/pom.xml
+++ b/containers/pax-exam-container-forked/pom.xml
@@ -57,6 +57,7 @@
         <dependency>
             <groupId>org.ops4j.pax.swissbox</groupId>
             <artifactId>pax-swissbox-framework</artifactId>
+            <version>1.8.3</version> 
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.swissbox</groupId>

--- a/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactory.java
+++ b/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactory.java
@@ -18,6 +18,7 @@
 package org.ops4j.pax.exam.forked;
 
 import java.io.File;
+import java.net.InetAddress;
 import java.net.URISyntaxException;
 import java.rmi.NoSuchObjectException;
 import java.rmi.NotBoundException;
@@ -111,9 +112,12 @@ public class ForkedFrameworkFactory {
         String rmiName = "ExamRemoteFramework-" + UUID.randomUUID().toString();
 
         try {
+            String address = InetAddress.getLoopbackAddress().getHostAddress();
+            System.setProperty("java.rmi.server.hostname", address);
             registry = LocateRegistry.createRegistry(port);
 
             Map<String, String> systemPropsNew = new HashMap<>(systemProperties);
+            systemPropsNew.put("java.rmi.server.hostname", address);
             systemPropsNew.put(RemoteFramework.RMI_PORT_KEY, Integer.toString(port));
             systemPropsNew.put(RemoteFramework.RMI_NAME_KEY, rmiName);
             String[] vmOptions = buildSystemProperties(vmArgs, systemPropsNew);
@@ -220,7 +224,8 @@ public class ForkedFrameworkFactory {
 
         do {
             try {
-                Registry reg = LocateRegistry.getRegistry(_port);
+                String address = InetAddress.getLoopbackAddress().getHostAddress();
+                Registry reg = LocateRegistry.getRegistry(address, _port);
                 framework = (RemoteFramework) reg.lookup(rmiName);
             }
             catch (RemoteException e) {


### PR DESCRIPTION
this appears e.g. on Fedora Linux on a laptop with two network adapters
(WiFi and wired Ethernet), if the hostname is not listed in /etc/hosts,
due to use of LocateRegistry -> InetAddress.getLocalHost(), but can also
occur under other network configurations.
    
This change fixes the problem in pax-exam-container-forked; but [also
needed changes in Pax Swissbox](https://github.com/ops4j/org.ops4j.pax.swissbox/pull/4), thus the uprade to a new version.
    
see also
http://blog2.vorburger.ch/2017/04/java-local-rmi-using-jdks-inetaddress.html