### PR TITLE
Fix Karaf[34]TestContainerITest

### DIFF
--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/AbstractKarafTestContainerITest.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/AbstractKarafTestContainerITest.java
@@ -43,16 +43,18 @@ import org.osgi.framework.ServiceReference;
 @RunWith(PaxExam.class)
 public abstract class AbstractKarafTestContainerITest {
 
-    private static final MavenArtifactUrlReference KARAF_URL = maven("org.apache.karaf", "apache-karaf").type("zip");
+    private final MavenArtifactUrlReference KARAF_URL = maven("org.apache.karaf", "apache-karaf").type("zip");
 
     @Inject
     private BundleContext bc;
 
     @Configuration
     public Option[] config() {
+        String karafVersion = karafVersion();
         return new Option[] {
-            karafDistributionConfiguration().frameworkUrl(KARAF_URL).karafVersion(karafVersion()).useDeployFolder(false).unpackDirectory(new File("target/paxexam/unpack/")),
-            configureConsole().ignoreLocalConsole().startRemoteShell(), logLevel(LogLevel.INFO)
+            karafDistributionConfiguration().frameworkUrl(KARAF_URL.version(karafVersion))
+                .karafVersion(karafVersion).useDeployFolder(false).unpackDirectory(new File("target/paxexam/unpack/")),
+            configureConsole().startLocalConsole().ignoreRemoteShell(), logLevel(LogLevel.INFO)
         };
     }
 

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/Karaf3TestContainerITest.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/Karaf3TestContainerITest.java
@@ -21,6 +21,6 @@ public class Karaf3TestContainerITest extends AbstractKarafTestContainerITest {
 
     @Override
     protected String getDefaultKarafVersion() {
-        return "4.1.1";
+        return "3.0.8";
     }
 }

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/Karaf4TestContainerITest.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/Karaf4TestContainerITest.java
@@ -21,6 +21,6 @@ public class Karaf4TestContainerITest extends AbstractKarafTestContainerITest {
 
     @Override
     protected String getDefaultKarafVersion() {
-        return "3.0.8";
+        return "4.1.1";
     }
 }


### PR DESCRIPTION
it was actually completely broken; as karafVersion() does not specify
which version to download, just adapt the start up; the frameworkUrl)(
needs a version() to choose between Karaf 3 & 4.. also can't be static.

Changed from ignore.ignoreLocalConsole().startRemoteShell() to
startLocalConsole().ignoreRemoteShell() instead, as it's handy to see
the Karaf banner on start up to recognize the version; and the remote
is not needed.

Also the versions were actually inavertedly inverted between *3/4Test* ;)