### PR TITLE
[PAXEXAM-811] ReactorManager skip reflect.InvocationTargetException

### DIFF
--- a/core/pax-exam-spi/src/main/java/org/ops4j/pax/exam/spi/reactors/ReactorManager.java
+++ b/core/pax-exam-spi/src/main/java/org/ops4j/pax/exam/spi/reactors/ReactorManager.java
@@ -183,8 +183,17 @@ public class ReactorManager {
         try {
             addConfigurationsToReactor(_testClass, testClassInstance);
         }
-        catch (IllegalAccessException | InvocationTargetException exc) {
+        catch (IllegalAccessException exc) {
             throw new TestContainerException(exc);
+        }
+        catch (InvocationTargetException exc) {
+            Throwable cause = exc.getCause();
+            if (cause instanceof AssertionError) {
+                throw (AssertionError)cause;
+            } 
+            else {
+                throw new TestContainerException(cause);
+            }
         }
         return reactor;
     }


### PR DESCRIPTION
Just for clearer stack traces, see discussion in JIRA.