### PR TITLE
[PAXEXAM-816] Update itest POMs to 4.10.1-SNAPSHOT

### DIFF
--- a/itest/cdi/pom.xml
+++ b/itest/cdi/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../pom</relativePath>
     </parent>
 

--- a/itest/cdi/src/it/regression-cdi-invalid/pom.xml
+++ b/itest/cdi/src/it/regression-cdi-invalid/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-cdi</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/cdi/src/it/regression-cdi-probe/pom.xml
+++ b/itest/cdi/src/it/regression-cdi-probe/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-cdi</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/cdi/src/it/regression-cdi-testng/pom.xml
+++ b/itest/cdi/src/it/regression-cdi-testng/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-cdi</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/itest/cdi/src/it/regression-cdi/pom.xml
+++ b/itest/cdi/src/it/regression-cdi/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-cdi</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/cdi/src/it/regression-deltaspike/pom.xml
+++ b/itest/cdi/src/it/regression-deltaspike/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-cdi</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/javaee/pom.xml
+++ b/itest/javaee/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../pom</relativePath>
     </parent>
 

--- a/itest/javaee/src/it/regression-javaee-data/pom.xml
+++ b/itest/javaee/src/it/regression-javaee-data/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-javaee</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/javaee/src/it/regression-javaee-jboss-module/pom.xml
+++ b/itest/javaee/src/it/regression-javaee-jboss-module/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-javaee</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/javaee/src/it/regression-javaee-moviefun/pom.xml
+++ b/itest/javaee/src/it/regression-javaee-moviefun/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-javaee</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/javaee/src/it/regression-javaee-testng/pom.xml
+++ b/itest/javaee/src/it/regression-javaee-testng/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-javaee</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/javaee/src/it/regression-javaee-userprobe/pom.xml
+++ b/itest/javaee/src/it/regression-javaee-userprobe/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-javaee</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/javaee/src/it/regression-javaee/pom.xml
+++ b/itest/javaee/src/it/regression-javaee/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-javaee</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/karaf/pom.xml
+++ b/itest/karaf/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../pom</relativePath>
     </parent>
 

--- a/itest/karaf/src/it/regression-karaf/pom.xml
+++ b/itest/karaf/src/it/regression-karaf/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../../../../pom</relativePath>
     </parent>
 

--- a/itest/osgi/pom.xml
+++ b/itest/osgi/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../pom</relativePath>
     </parent>
 

--- a/itest/osgi/src/it/regression-maven-plugin/pom.xml
+++ b/itest/osgi/src/it/regression-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../../../../pom</relativePath>
     </parent>
 

--- a/itest/osgi/src/it/regression-multi/pom.xml
+++ b/itest/osgi/src/it/regression-multi/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../../../../pom</relativePath>
     </parent>
 

--- a/itest/osgi/src/it/regression-plumbing/pom.xml
+++ b/itest/osgi/src/it/regression-plumbing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../../../../pom</relativePath>
     </parent>
 

--- a/itest/osgi/src/it/regression-testng-perclass/pom.xml
+++ b/itest/osgi/src/it/regression-testng-perclass/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../../../../pom</relativePath>
     </parent>
 

--- a/itest/osgi/src/it/regression-testng/pom.xml
+++ b/itest/osgi/src/it/regression-testng/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../../../../pom</relativePath>
     </parent>
 

--- a/itest/pom.xml
+++ b/itest/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../pom</relativePath>
     </parent>
 

--- a/itest/web/pom.xml
+++ b/itest/web/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax</groupId>
         <artifactId>exam</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../pom</relativePath>
     </parent>
 

--- a/itest/web/src/it/regression-web-spring-userprobe/pom.xml
+++ b/itest/web/src/it/regression-web-spring-userprobe/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-web</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/web/src/it/regression-web-spring/pom.xml
+++ b/itest/web/src/it/regression-web-spring/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-web</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/itest/web/src/it/regression-web/pom.xml
+++ b/itest/web/src/it/regression-web/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.ops4j.pax.exam.itest</groupId>
         <artifactId>exam-itest-web</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.1-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 


### PR DESCRIPTION
This allows the integration tests to be run against the current tree. They still fail at the JavaEE tests.