### PR TITLE
[PAXEXAM-723] Allow for overriding JUnit related bundles within the Karaf container

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
@@ -77,6 +77,7 @@ import org.ops4j.pax.exam.karaf.options.KeepRuntimeFolderOption;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption;
 import org.ops4j.pax.exam.karaf.options.configs.CustomProperties;
 import org.ops4j.pax.exam.karaf.options.configs.FeaturesCfg;
+import org.ops4j.pax.exam.karaf.options.libraries.OverrideJUnitBundlesOption;
 import org.ops4j.pax.exam.options.BootDelegationOption;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.PropagateSystemPropertyOption;
@@ -167,8 +168,10 @@ public class KarafTestContainer implements TestContainer {
             List<KarafDistributionConfigurationFileOption> options = new ArrayList<>(
                 Arrays.asList(subsystem.getOptions(KarafDistributionConfigurationFileOption.class)));
             options.addAll(fromFeatureOptions(subsystem.getOptions(KarafFeaturesOption.class)));
-            options.addAll(fromFeatureOptions(KarafDistributionOption.features(EXAM_REPO_URL,
-                "exam")));
+            String usedExamFeature = shouldInjectJUnitBundles(system)
+                    ? "exam"
+                    : "exam-no-junit";
+            options.addAll(fromFeatureOptions(KarafDistributionOption.features(EXAM_REPO_URL, usedExamFeature)));
 
             if (framework.isUseDeployFolder()) {
                 deployer.copyReferencedArtifactsToDeployFolder();
@@ -190,6 +193,12 @@ public class KarafTestContainer implements TestContainer {
         return this;
     }
 
+    private boolean shouldInjectJUnitBundles(ExamSystem _system) {
+        Option[] options = _system.getOptions(OverrideJUnitBundlesOption.class);  
+        LOGGER.info("Found {} options when requesting OverrideJUnitBundlesOption.class", options.length);
+        return options.length == 0;
+    }
+    
     private KarafManipulator createVersionAdapter(File karafBase) {
         File karafEtc = new File(karafBase, framework.getKarafEtc());
         File distributionInfo = new File(karafEtc, "distribution.info");

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafDistributionOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/KarafDistributionOption.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.karaf.options.libraries.OverrideJUnitBundlesOption;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
 import org.ops4j.pax.exam.options.UrlReference;
 import org.ops4j.pax.exam.options.extra.VMOption;
@@ -393,5 +394,14 @@ public final class KarafDistributionOption {
     public static KarafFeaturesOption features(final UrlReference repositoryUrl,
         final String... features) {
         return new KarafFeaturesOption(repositoryUrl, features);
+    }
+    
+    /**
+     * A convenience method that disables the default Junit deployment.
+     *
+     * @return option
+     */
+    public static OverrideJUnitBundlesOption overrideJUnitBundles() {
+        return new OverrideJUnitBundlesOption();
     }
 }

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/libraries/OverrideJUnitBundlesOption.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/options/libraries/OverrideJUnitBundlesOption.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 Jamie Kemp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.ops4j.pax.exam.karaf.options.libraries;
+ 
+ import org.ops4j.pax.exam.Option;
+ 
+ public class OverrideJUnitBundlesOption implements Option {
+ }

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/AbstractKarafTestContainerITest.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/AbstractKarafTestContainerITest.java
@@ -37,6 +37,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
@@ -73,6 +74,17 @@ public abstract class AbstractKarafTestContainerITest {
             .getServiceReference("org.apache.karaf.system.SystemService");
         Object service = bc.getService(serviceRef);
         assertThat(service, is(notNullValue()));
+    }
+    
+    public Bundle findBundle(String symbolicName) {
+        Bundle[] bundles = bc.getBundles();
+        for (Bundle bundle : bundles) {
+            if (bundle.getSymbolicName().equals(symbolicName)) {
+                return bundle;
+            }
+        }
+    
+        return null;
     }
 
 }

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/ValidateDefaultJUnitBundles.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/ValidateDefaultJUnitBundles.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ops4j.pax.exam.karaf.container;
+
+import static org.junit.Assert.assertNotNull;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+@RunWith(PaxExam.class)
+public class ValidateDefaultJUnitBundles extends Karaf4TestContainerITest {
+
+    @Test
+    public void testDefaultJUnitBundlesPresent() throws Exception {
+        //Test for the presence of standard test libs
+        assertNotNull(findBundle("org.ops4j.pax.tipi.hamcrest.core"));
+        assertNotNull(findBundle("org.ops4j.pax.tipi.junit"));
+    }
+}

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/ValidateOverridingJUnitBundles.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/ValidateOverridingJUnitBundles.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ops4j.pax.exam.karaf.container;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionOption;
+import org.osgi.framework.Bundle;
+
+@RunWith(PaxExam.class)
+public class ValidateOverridingJUnitBundles extends Karaf4TestContainerITest {
+
+    @Override
+    @Configuration
+    public Option[] config() {
+        return new Option[] {
+            composite(super.config()),
+            KarafDistributionOption.overrideJUnitBundles(),
+            mavenBundle().groupId("org.apache.servicemix.bundles").artifactId("org.apache.servicemix.bundles.hamcrest").version("1.3_1"),
+            mavenBundle().groupId("org.ops4j.pax.tipi").artifactId("org.ops4j.pax.tipi.junit").version("4.12.0.1"),
+            mavenBundle().groupId("org.ops4j.pax.exam").artifactId("pax-exam-invoker-junit").version("4.10.0")
+        };
+    }
+    
+    @Test
+    public void testOverriddenJUnitBundlesPresent() throws Exception {  
+        Bundle hamcrestBundle = findBundle("org.apache.servicemix.bundles.hamcrest");
+        assertNotNull(hamcrestBundle);
+        assertThat(hamcrestBundle.getVersion().toString(), equalTo("1.3.0.1"));
+        
+        Bundle junitBundle = findBundle("org.ops4j.pax.tipi.junit");
+        assertNotNull(junitBundle);
+        assertThat(junitBundle.getVersion().toString(), equalTo("4.12.0.1"));
+        
+        //As we have not included it, ensure org.ops4j.pax.tipi.hamcrest.core is not present
+        assertNull(findBundle("org.ops4j.pax.tipi.hamcrest.core"));
+    }
+}

--- a/features/src/main/resources/features.xml
+++ b/features/src/main/resources/features.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="pax-exam-features-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
-    <feature name="exam" version="${project.version}">
+    <feature name="exam-no-junit" version="${project.version}">
         <bundle>mvn:org.ops4j.base/ops4j-base-lang/${dependency.base.version}</bundle>
         <bundle>mvn:org.ops4j.base/ops4j-base-monitors/${dependency.base.version}</bundle>
         <bundle>mvn:org.ops4j.base/ops4j-base-net/${dependency.base.version}</bundle>
@@ -17,10 +17,13 @@
         <bundle>mvn:org.ops4j.pax.exam/pax-exam/${project.version}</bundle>
         <bundle>mvn:org.ops4j.pax.exam/pax-exam-extender-service/${project.version}</bundle>
         <bundle>mvn:org.ops4j.pax.exam/pax-exam-container-rbc/${project.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-atinject_1.0_spec/1.0</bundle>
+        <bundle>mvn:org.ops4j.pax.exam/pax-exam-inject/${project.version}</bundle>
+    </feature>
+    <feature name="exam" version="${project.version}">
+        <feature version="${project.version}">exam-no-junit</feature>
         <bundle>mvn:org.ops4j.pax.tipi/org.ops4j.pax.tipi.hamcrest.core/${dependency.tipi.hamcrest.version}</bundle>
         <bundle>mvn:org.ops4j.pax.tipi/org.ops4j.pax.tipi.junit/${dependency.tipi.junit.version}</bundle>
         <bundle>mvn:org.ops4j.pax.exam/pax-exam-invoker-junit/${project.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-atinject_1.0_spec/1.0</bundle>
-        <bundle>mvn:org.ops4j.pax.exam/pax-exam-inject/${project.version}</bundle>
     </feature>
 </features>


### PR DESCRIPTION
This change allows test libraries to be optionally switched out for customised versions. In the provided test this is from the pax-exam's own wrapped hamcrest-core to the servicemix wrapped hamcrest-all, exposing access to hamcrest-library.

This PR would supersede #35.