### PR TITLE
Fix CirleCI's dependency:go-offline on pom.xml version number upgrades

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,10 @@
 machine:
   java:
     version: openjdk8
+
+dependencies:
+  override:
+    # https://issues.apache.org/jira/browse/MDEP-516
+    # alternative, just: mvn -B dependency:resolve-plugins
+    - mvn --fail-never dependency:go-offline || true
+


### PR DESCRIPTION
due to https://issues.apache.org/jira/browse/MDEP-516
(maybe also related to https://issues.apache.org/jira/browse/MDEP-82)

This seems to be how most projects found e.g. on GitHub
deal with this problem (search for circle.yml files containing
"dependency:go-offline", and many will have something like this).