### PR TITLE
[PAXEXAM-674] Configurations and probe builders do not need to be static

### DIFF
--- a/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedFrameworkMethod.java
+++ b/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedFrameworkMethod.java
@@ -20,11 +20,10 @@ import org.junit.runners.model.FrameworkMethod;
 import org.ops4j.pax.exam.TestAddress;
 
 /**
- * Decorates a framework method with a parameter index. Used for parameterized tests
- * with {@code PaxExamParameterized}.
- * 
+ * Decorates a framework method with a parameter index. Used for parameterized tests with
+ * {@code PaxExamParameterized}.
+ *
  * @author Harald Wellmann
- * 
  */
 class ParameterizedFrameworkMethod extends DecoratedFrameworkMethod {
 
@@ -34,6 +33,16 @@ class ParameterizedFrameworkMethod extends DecoratedFrameworkMethod {
 
     @Override
     public String getName() {
-        return String.format("%s[%d]", frameworkMethod.getName(), address.arguments()[0]);
+
+        // arg[0] must be an integer (at least, for the JUnit runner).
+        // The customized (parameterized) name is given as a second argument.
+
+        String result;
+        if (this.address.arguments().length > 1)
+            result = String.format("%s", this.address.arguments()[1]);
+        else result = String.format("%s[%d]", this.frameworkMethod.getName(),
+            this.address.arguments()[0]);
+
+        return result;
     }
 }

--- a/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedProbeRunner.java
+++ b/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedProbeRunner.java
@@ -20,11 +20,10 @@ package org.ops4j.pax.exam.junit.impl;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.internal.runners.model.ReflectiveCallable;
 import org.junit.internal.runners.statements.Fail;
@@ -48,8 +47,9 @@ import org.ops4j.pax.exam.TestInstantiationInstruction;
 import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.spi.ExamReactor;
 import org.ops4j.pax.exam.spi.StagedExamReactor;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
 import org.ops4j.pax.exam.spi.reactors.ReactorManager;
-import org.ops4j.pax.exam.util.InjectorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,9 +57,8 @@ import org.slf4j.LoggerFactory;
  * JUnit runner for parameterized Pax Exam tests executed via an invoker. This runner is used for
  * all operation modes except CDI. See {@link Parameterized} for more details on specifying
  * parameter sets.
- * 
+ *
  * @author Harald Wellmann
- * 
  */
 public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
 
@@ -68,43 +67,112 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
     /**
      * Reactor manager singleton.
      */
-    private ReactorManager manager;
+    private final ReactorManager manager;
+
+    private final Map<TestAddress, ParameterizedContext> testAddressToContext = new LinkedHashMap<>();
+    private final Map<FrameworkMethod, TestAddress> methodToTestAddressMap = new LinkedHashMap<>();
+    private String parameterizedName;
 
     /**
-     * Staged reactor for this test class. This may actually be a reactor already staged for a
-     * previous test class, depending on the reactor strategy.
+     * Constructor.
+     *
+     * @param klass
+     * @throws InitializationError
      */
-    private StagedExamReactor stagedReactor;
-
-    private Map<FrameworkMethod, TestAddress> methodToTestAddressMap = new LinkedHashMap<FrameworkMethod, TestAddress>();
-
-    private Object[] parameters;
-
     public ParameterizedProbeRunner(Class<?> klass) throws InitializationError {
         super(klass);
         LOG.info("creating PaxExam runner for {}", klass);
-        manager = ReactorManager.getInstance();
+        this.manager = ReactorManager.getInstance();
+
         try {
-            ExamReactor examReactor = manager.prepareReactor(klass, null);
-            addTestsToReactor(examReactor, klass, null);
-            stagedReactor = manager.stageReactor();
+            // We use parameterized class instances to initialize
+            // the tests (in this constructor) and to run the tests.
+
+            // Every test has its own class.
+            // What differs is whether we isolate each one in its own reactor
+            // or if some share it. That depends on the reactor strategy.
+
+            // EXAM_REACTOR_STRATEGY_PER_METHOD => 1 reactor per test class instance.
+            // EXAM_REACTOR_STRATEGY_PER_CLASS => 1 reactor for all the test class instances.
+            // EXAM_REACTOR_STRATEGY_PER_SUITE => 1 reactor for all the test class instances.
+
+            // We need to know the strategy BEFORE creating any reactor.
+            // We could set ReactorManager#getStagingFactory public and/or static...
+            // We will do more simple (and limited). Tests classes must be explicitly
+            // annotated with the required strategy (no global/environment settings).
+            ExamReactorStrategy strategy = klass.getAnnotation(ExamReactorStrategy.class);
+            final boolean renew = PerMethod.class.equals(strategy.value()[0]);
+            if (renew) {
+                LOG.info("Parameterized tests with " + klass
+                    + " will be run in their own reactor each.");
+            } else {
+                LOG.info("Parameterized tests with " + klass + " will share the same reactor.");
+            }
+
+            // Except for the PerMethod strategy, the configuration method will need to be static.
+            // It does not make sense to be non-static anyway, the same container will be
+            // reused. So, a single configuration is enough and can be static.
+            ExamReactor examReactor = null;
+            if (!renew) {
+                examReactor = this.manager.prepareReactor(klass, null);
+            }
+
+            int index = 0;
+            for (Object[] params : allParameters()) {
+
+                // Instantiate the test class and prepare the reactor
+                Object testClassInstance = getTestClass().getOnlyConstructor().newInstance(params);
+
+                // For the PerMethod strategy, we build a new Exam reactor every time.
+                // This is the only case where the Configuration method doesn't need to be static.
+                if (renew) {
+                    examReactor = this.manager.prepareReactor(klass, testClassInstance);
+                }
+
+                // Now, prepare the tests
+                ParameterizedContext ctx = new ParameterizedContext();
+                ctx.testClassInstance = testClassInstance;
+                addTestsToReactor(examReactor, testClassInstance, params, index, ctx);
+
+                // Set the reactor in the context.
+                if (renew) {
+                    ctx.reactor = this.manager.stageReactor();
+                }
+
+                index++;
+            }
+
+            // Update the contexts?
+            // Only when we do not use the PerMethod strategy.
+            if (!renew) {
+                StagedExamReactor stagedReactor = this.manager.stageReactor();
+                for (ParameterizedContext ctx : this.testAddressToContext.values())
+                    ctx.reactor = stagedReactor;
+            }
         }
-        catch (IOException | ExamConfigurationException exc) {
+        catch (Throwable exc) {
             throw new InitializationError(exc);
         }
     }
 
     /**
-     * We decorate the super method by reactor setup and teardown. This method is called once per
-     * class. Note that the given reactor strategy decides whether or not the setup and teardown
-     * actually happens at this level.
+     * We decorate the super method by reactor setup and teardown.
+     * <p>
+     * This method is called once per class, which is logical, even with parameterized tests. Note
+     * that the given reactor strategy decides whether or not the setup and teardown actually
+     * happens at this level.
+     * </p>
      */
     @Override
     public void run(RunNotifier notifier) {
         LOG.info("running test class {}", getTestClass().getName());
         Class<?> testClass = getTestClass().getJavaClass();
+
+        // The reactor has the same kind/class.
+        // So, we can pick up any instance. The first one will be fine.
+        StagedExamReactor reactor = this.testAddressToContext.values().iterator().next().reactor;
         try {
-            manager.beforeClass(stagedReactor, testClass);
+            this.manager.beforeClass(reactor, testClass);
             super.run(notifier);
         }
         // CHECKSTYLE:SKIP : catch all wanted
@@ -114,7 +182,7 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
             notifier.fireTestFailure(new Failure(description, e));
         }
         finally {
-            manager.afterClass(stagedReactor, testClass);
+            this.manager.afterClass(reactor, testClass);
         }
     }
 
@@ -122,6 +190,7 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
      * Override to avoid running BeforeClass and AfterClass by the driver. They shall only be run by
      * the container when using a probe invoker.
      */
+    @Override
     protected Statement classBlock(final RunNotifier notifier) {
         Statement statement = childrenInvoker(notifier);
         return statement;
@@ -131,7 +200,8 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
      * Override to avoid running Before, After and Rule methods by the driver. They shall only be
      * run by the container when using a probe invoker.
      */
-    protected Statement methodBlock(FrameworkMethod method) {
+    @Override
+    protected Statement methodBlock(final FrameworkMethod method) {
 
         Object test;
         try {
@@ -140,7 +210,7 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
                 @Override
                 // CHECKSTYLE:SKIP : Base class API
                 protected Object runReflectiveCall() throws Throwable {
-                    return createTest();
+                    return retrieveTestClassInstance(method);
                 }
             };
             test = reflectiveCallable.run();
@@ -161,33 +231,36 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
      */
     @Override
     protected List<FrameworkMethod> getChildren() {
-        if (methodToTestAddressMap.isEmpty()) {
+        if (this.methodToTestAddressMap.isEmpty()) {
             fillChildren();
         }
-        return new ArrayList<FrameworkMethod>(methodToTestAddressMap.keySet());
+        return new ArrayList<FrameworkMethod>(this.methodToTestAddressMap.keySet());
     }
 
     private void fillChildren() {
-        Set<TestAddress> targets = stagedReactor.getTargets();
-        TestDirectory testDirectory = TestDirectory.getInstance();
-        for (TestAddress address : targets) {
-            FrameworkMethod frameworkMethod = (FrameworkMethod) manager.lookupTestMethod(address
-                .root());
 
-            // The reactor may contain targets which do not belong to the current test class
-            if (frameworkMethod == null) {
-                continue;
-            }
-            Class<?> frameworkMethodClass = frameworkMethod.getMethod().getDeclaringClass();
-            String className = frameworkMethodClass.getName();
-            String methodName = frameworkMethod.getName();
+        for (ParameterizedContext ctx : this.testAddressToContext.values()) {
+            for (TestAddress address : ctx.reactor.getTargets()) {
 
-            if (frameworkMethodClass.isAssignableFrom(getTestClass().getJavaClass())) {
+                FrameworkMethod frameworkMethod = (FrameworkMethod) this.manager
+                    .lookupTestMethod(address.root());
+
+                // The reactor may contain targets which do not belong to the current test class
+                if (frameworkMethod == null)
+                    continue;
+
+                Class<?> frameworkMethodClass = frameworkMethod.getMethod().getDeclaringClass();
+                String className = frameworkMethodClass.getName();
+                String methodName = frameworkMethod.getName();
+
+                if (!frameworkMethodClass.isAssignableFrom(getTestClass().getJavaClass()))
+                    continue;
+
+                TestInstantiationInstruction ti = new TestInstantiationInstruction(className + ";"
+                    + methodName);
                 FrameworkMethod method = new ParameterizedFrameworkMethod(address, frameworkMethod);
-                testDirectory.add(address, new TestInstantiationInstruction(className + ";"
-                    + methodName));
-
-                methodToTestAddressMap.put(method, address);
+                TestDirectory.getInstance().add(address, ti);
+                this.methodToTestAddressMap.put(method, address);
             }
         }
     }
@@ -202,37 +275,39 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
      * <p>
      * This way, we can register all test methods in the reactor before the actual test execution
      * starts.
-     * 
+     *
      * @param reactor
-     * @param testClass
      * @param testClassInstance
+     * @param params
+     * @param index
+     * @param ctx
      * @throws IOException
      * @throws ExamConfigurationException
      */
-    private void addTestsToReactor(ExamReactor reactor, Class<?> testClass, Object testClassInstance)
-        throws IOException, ExamConfigurationException {
-        TestProbeBuilder probe = manager.createProbeBuilder(testClassInstance);
+    private void addTestsToReactor(ExamReactor reactor, Object testClassInstance, Object[] params,
+        int index, ParameterizedContext ctx) throws IOException, ExamConfigurationException {
 
-        Iterator<Object[]> it = null;
-        int index = 0;
-        try {
-            it = allParameters().iterator();
-        }
-        // CHECKSTYLE:SKIP : JUnit API
-        catch (Throwable t) {
-            throw new ExamConfigurationException(t.getMessage());
-        }
+        TestProbeBuilder probe = this.manager.createProbeBuilder(testClassInstance);
+        for (FrameworkMethod s : super.getChildren()) {
 
-        while (it.hasNext()) {
-            parameters = it.next();
-            // probe.setAnchor( testClass );
-            for (FrameworkMethod s : super.getChildren()) {
-                // record the method -> adress matching
-                TestAddress address = probe.addTest(testClass, s.getMethod().getName(), index);
-                manager.storeTestMethod(address, s);
+            // record the method -> address matching
+            TestAddress address;
+            String mName = s.getMethod().getName();
+            if (this.parameterizedName != null) {
+                String name = this.parameterizedName.replace("{index}", String.valueOf(index));
+                name = name.replace("{method}", s.getMethod().getName());
+
+                name = MessageFormat.format(name, params);
+                address = probe.addTest(testClassInstance.getClass(), mName, index, name);
             }
-            index++;
+            else {
+                address = probe.addTest(testClassInstance.getClass(), mName, index);
+            }
+
+            this.testAddressToContext.put(address, ctx);
+            this.manager.storeTestMethod(address, s);
         }
+
         reactor.addProbe(probe);
     }
 
@@ -240,6 +315,7 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
      * When using a probe invoker, we replace the super method and invoke the test method indirectly
      * via the reactor.
      */
+    @Override
     protected synchronized Statement methodInvoker(final FrameworkMethod method, final Object test) {
 
         return new Statement() {
@@ -247,13 +323,19 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
             @Override
             // CHECKSTYLE:SKIP : Statement API
             public void evaluate() throws Throwable {
-                TestAddress address = methodToTestAddressMap.get(method);
-                TestAddress root = address.root();
+
+                TestAddress address = ParameterizedProbeRunner.this.methodToTestAddressMap
+                    .get(method);
 
                 LOG.debug("Invoke " + method.getName() + " @ " + address + " Arguments: "
-                    + root.arguments());
+                    + Arrays.toString(address.root().arguments()));
+
                 try {
-                    stagedReactor.invoke(address);
+                    // Find the right reactor and invoke it
+                    ParameterizedContext ctx = ParameterizedProbeRunner.this.testAddressToContext
+                        .get(address.root());
+
+                    ctx.reactor.invoke(address);
                 }
                 // CHECKSTYLE:SKIP : StagedExamReactor API
                 catch (Exception e) {
@@ -264,23 +346,20 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
         };
     }
 
-    /**
-     * Creates an instance of the current test class. When using a probe invoker, this simply
-     * delegates to super. Otherwise, we perform injection on the instance created by the super
-     * method.
-     * <p>
-     * In this case, an {@link InjectorFactory} is obtained via SPI lookup.
-     */
-    @Override
-    protected Object createTest() throws Exception {
-        return getTestClass().getOnlyConstructor().newInstance(parameters);
+    protected Object retrieveTestClassInstance(FrameworkMethod method) throws Exception {
+
+        TestAddress address = ParameterizedProbeRunner.this.methodToTestAddressMap.get(method);
+        ParameterizedContext ctx = this.testAddressToContext.get(address.root());
+        return ctx.testClassInstance;
     }
 
     @SuppressWarnings("unchecked")
     // CHECKSTYLE:SKIP - JUnit API
     private Iterable<Object[]> allParameters() throws Throwable {
+
         Object params = getParametersMethod().invokeExplosively(null);
         if (params instanceof Iterable) {
+            this.parameterizedName = getParametersMethod().getAnnotation(Parameters.class).name();
             return (Iterable<Object[]>) params;
         }
         else {
@@ -322,5 +401,30 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
 
     private boolean fieldsAreAnnotated() {
         return !getAnnotatedFieldsByParameter().isEmpty();
+    }
+
+    /**
+     * A bean that allow various bindings.
+     * <p>
+     * Parameterized tests hardly fit into the Exam code organization. So that parameterized tests
+     * rely on the most minimalist assumptions, we must remember for every test which reactor must
+     * be used.
+     * </p>
+     * <p>
+     * Most of the time, this will be useless, except for tests that use different configurations
+     * and use the PerMethod reactor strategy.
+     * </p>
+     *
+     * @author Vincent Zurczak - Linagora
+     */
+    private static class ParameterizedContext {
+
+        public StagedExamReactor reactor;
+        public Object testClassInstance;
+
+        @Override
+        public String toString() {
+            return this.testClassInstance.getClass().getSimpleName();
+        }
     }
 }

--- a/itest/karaf/src/it/regression-karaf/src/test/java/org/ops4j/pax/exam/regression/karaf/ParameterizedConfigurationTest.java
+++ b/itest/karaf/src/it/regression-karaf/src/test/java/org/ops4j/pax/exam/regression/karaf/ParameterizedConfigurationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013 Harald Wellmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ops4j.pax.exam.regression.karaf;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Info;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExamParameterized;
+import org.ops4j.pax.exam.sample8.ds.Calculator;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+@RunWith(PaxExamParameterized.class)
+@ExamReactorStrategy(PerMethod.class)
+public class ParameterizedConfigurationTest {
+
+	private static final String SYSTEM_PROPERTY = "pax.parameterized.value";
+    private static int paramIndex = 1;
+
+    @Inject
+    private Calculator calculator;
+
+    private final int a;
+    private final int b;
+    private final int sum;
+    private final String sp;
+
+
+    @Parameters
+    public static List<Object[]> getParameters() {
+        return Arrays.asList(new Object[][] {
+            {2, 3, 5, "a"},
+            {5, 6, 11, "ab"},
+            {6, 2, 8, "abc"}
+        });
+    }
+
+    @Configuration
+    public Option[] config() {
+        return new Option[] {
+            RegressionConfiguration.regressionDefaults(),
+            mavenBundle("org.apache.felix", "org.apache.felix.scr", "1.6.2"),
+            mavenBundle("org.ops4j.pax.exam.samples", "pax-exam-sample8-ds", Info.getPaxExamVersion()),
+            systemProperty(SYSTEM_PROPERTY).value(this.sp)};
+    }
+
+    public ParameterizedConfigurationTest(int a, int b, int sum, String systemProperty) {
+        this.a = a;
+        this.b = b;
+        this.sum = sum;
+        this.sp = systemProperty;
+    }
+
+    @Test
+    public void add() {
+        assertThat(this.calculator.add(this.a, this.b), is(this.sum));
+
+        // Each test runs in its own container (isolation).
+        // So, even if we update a static field, other parameterized class instances
+        // should not be impacted.
+        assertThat(paramIndex, is(1));
+        paramIndex++;
+
+        // The system property (set in the PAX configuration) must match the internal field.
+        String currentProperty = System.getProperty(SYSTEM_PROPERTY);
+        assertThat(currentProperty, notNullValue());
+        assertThat(currentProperty, is(this.sp));
+    }
+}


### PR DESCRIPTION
- Repair the parameterized runner for non-PerMethod strategies.
- Add an integration test for parameterized PAX configurations.
- Format the code with the right formatter.