### PR TITLE
Add support for parameterized named tests

### DIFF
--- a/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedFrameworkMethod.java
+++ b/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedFrameworkMethod.java
@@ -16,6 +16,8 @@
  */
 package org.ops4j.pax.exam.junit.impl;
 
+import java.text.MessageFormat;
+
 import org.junit.runners.model.FrameworkMethod;
 import org.ops4j.pax.exam.TestAddress;
 
@@ -34,6 +36,12 @@ class ParameterizedFrameworkMethod extends DecoratedFrameworkMethod {
 
     @Override
     public String getName() {
-        return String.format("%s[%d]", frameworkMethod.getName(), address.arguments()[0]);
+        return String.format("%s%s", frameworkMethod.getName(), nameFor((Integer) address.arguments()[0], (String) address.arguments()[1], (Object[]) address.arguments()[2]));
+    }
+
+    private String nameFor(int index, String namePattern, Object[] parameters) {
+        String finalPattern = namePattern.replaceAll("\\{index\\}", Integer.toString(index));
+        String name = MessageFormat.format(finalPattern, parameters);
+        return "[" + name + "]";
     }
 }

--- a/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedProbeRunner.java
+++ b/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/impl/ParameterizedProbeRunner.java
@@ -215,8 +215,11 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
 
         Iterator<Object[]> it = null;
         int index = 0;
+        String parameterizedName = null;
+
         try {
             it = allParameters().iterator();
+            parameterizedName = getParametersMethod().getAnnotation(Parameters.class).name();
         }
         // CHECKSTYLE:SKIP : JUnit API
         catch (Throwable t) {
@@ -228,7 +231,7 @@ public class ParameterizedProbeRunner extends BlockJUnit4ClassRunner {
             // probe.setAnchor( testClass );
             for (FrameworkMethod s : super.getChildren()) {
                 // record the method -> adress matching
-                TestAddress address = probe.addTest(testClass, s.getMethod().getName(), index);
+                TestAddress address = probe.addTest(testClass, s.getMethod().getName(), index, parameterizedName, parameters);
                 manager.storeTestMethod(address, s);
             }
             index++;

--- a/itest/karaf/src/it/regression-karaf/src/test/java/org/ops4j/pax/exam/regression/karaf/ParameterizedTest.java
+++ b/itest/karaf/src/it/regression-karaf/src/test/java/org/ops4j/pax/exam/regression/karaf/ParameterizedTest.java
@@ -52,7 +52,7 @@ public class ParameterizedTest {
     private int sum;
     
 
-    @Parameters
+    @Parameters(name = "{0} + {1} = {2}")
     public static List<Object[]> getParameters() {
         return Arrays.asList(new Object[][] {
             {2, 3, 5},


### PR DESCRIPTION
The parameterized test runner is unable to evaluate parameter values when creating the test names. Adding support for this would add clarity to the tests being executed. https://github.com/junit-team/junit4/wiki/parameterized-tests

This topic was discussed briefly in https://ops4j1.jira.com/browse/PAXEXAM-674 . I tried to make a separate issue but did not have account access to do so.