### PR TITLE
Make the Java major version detection for Karaf more solid

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/JavaVersionUtil.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/JavaVersionUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam.karaf.container.internal;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JavaVersionUtil {
+
+    private static final Pattern MAJOR_VERSION_PATTERN = Pattern.compile("^([0-9]+)[^0-9].*");
+
+    private static final Pattern ONE_VERSION_PATTERN = Pattern.compile("^1\\.([0-9]+)[^0-9].*");
+
+    public static int getMajorVersion(String javaVersion) {
+        Matcher majorVersionMatcher = MAJOR_VERSION_PATTERN.matcher(javaVersion);
+
+        if (!majorVersionMatcher.matches()) {
+            throw getUnableToParseVersionException(javaVersion);
+        }
+
+        int majorVersion = Integer.parseInt(majorVersionMatcher.group(1));
+
+        // we are in the case of Java >= 9
+        if (majorVersion > 1) {
+            return majorVersion;
+        }
+
+        // we are in the case of Java < 9 (1.7, 1.8)
+        Matcher oneVersionMatcher = ONE_VERSION_PATTERN.matcher(javaVersion);
+        if (!oneVersionMatcher.matches()) {
+            throw getUnableToParseVersionException(javaVersion);
+        }
+
+        return Integer.parseInt(oneVersionMatcher.group(1));
+    }
+
+    private static IllegalArgumentException getUnableToParseVersionException(String version) {
+        return new IllegalArgumentException(
+                String.format(Locale.ROOT, "We are unable to parse Java version '%1$s'.", version));
+    }
+}

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
@@ -118,12 +118,7 @@ public class KarafTestContainer implements TestContainer {
     private static boolean isJava9Compatible;
     
     static {
-        String version = System.getProperty("java.version");
-        if (version.indexOf(".") > 0) {
-            version = version.substring(0, version.indexOf("."));
-        }
-        
-        setJava9Compatible(Integer.valueOf(version) >= 9);
+        setJava9Compatible(JavaVersionUtil.getMajorVersion(System.getProperty("java.version")) >= 9);
     }
 
     public KarafTestContainer(ExamSystem system,

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/internal/JavaVersionUtilTest.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/internal/JavaVersionUtilTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam.karaf.container.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class JavaVersionUtilTest {
+
+    @Test
+    public void testVersions() {
+        assertEquals(8, JavaVersionUtil.getMajorVersion("1.8.0_171"));
+        assertEquals(9, JavaVersionUtil.getMajorVersion("9.0.4"));
+        assertEquals(10, JavaVersionUtil.getMajorVersion("10.0.1"));
+        assertEquals(11, JavaVersionUtil.getMajorVersion("11-ea"));
+    }
+}


### PR DESCRIPTION
The goal of this PR is to make Java major detection more solid.

Early access builds have the following pattern MAJOR-ea (typically 11-ea).

I was unable to log in on your issue tracker to create a JIRA and affect it to the commit message, is it open to external contributors?