### PR TITLE
Backport: [PAXEXAM-887] Do not deploy compendium bundle

### DIFF
--- a/core/pax-exam-spi/src/main/java/org/ops4j/pax/exam/spi/PaxExamRuntime.java
+++ b/core/pax-exam-spi/src/main/java/org/ops4j/pax/exam/spi/PaxExamRuntime.java
@@ -200,8 +200,6 @@ public class PaxExamRuntime {
                 START_LEVEL_SYSTEM_BUNDLES),
             url("link:classpath:META-INF/links/org.ops4j.pax.extender.service.link").startLevel(
                 START_LEVEL_SYSTEM_BUNDLES),
-            url("link:classpath:META-INF/links/org.osgi.compendium.link").startLevel(
-                START_LEVEL_SYSTEM_BUNDLES),
 
             when(logging.equals(Constants.EXAM_LOGGING_PAX_LOGGING)).useOptions(
                 url("link:classpath:META-INF/links/org.ops4j.pax.logging.api.link").startLevel(


### PR DESCRIPTION
Backport of the fix for PAXEXAM-887 towards the 4.x branch.