### PR TITLE
Fix dependency conflict issue

### DIFF
--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -681,7 +681,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>14.0</version>
+                <version>18.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Hi, there are multiple versions of **com.google.guava:guava:jar** in **org.ops4j.pax.exam2-exam-reactor-4.13.1** (**org.ops4j.pax.exam2-exam-reactor-4.13.1\containers\pax-exam-container-weld** module). As shown in the following dependency tree, according to Maven's dependency management strategy, only **com.google.guava:guava:jar:14.0** can be loaded, and **com.google.guava:guava:jar:18.0** will be shadowed.

Your project references the method **com.google.common.collect.Lists$TransformingRandomAccessList.listIterator(int)** via the following invocation path, which is included in the shadowed version **com.google.guava:guava:jar:18.0**. However, this method is missing in the actual loaded version **com.google.guava:guava:jar:14.0**. Surprisingly, it will not cause NoSuchMethodError at rumtime.


```
<org.jboss.weld.probe.Resource: void handle(org.jboss.weld.probe.Resource$HttpMethod,org.jboss.weld.probe.JsonDataProvider,java.lang.String[],javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse)> C:\Users\Flipped\.m2\repository\org\jboss\weld\probe\weld-probe-core\2.3.2.Final\weld-probe-core-2.3.2.Final.jar
<org.jboss.weld.probe.Resource$Handler: void handle(org.jboss.weld.probe.Resource$HttpMethod,org.jboss.weld.probe.JsonDataProvider,java.lang.String[],javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse)> C:\Users\Flipped\.m2\repository\org\jboss\weld\probe\weld-probe-core\2.3.2.Final\weld-probe-core-2.3.2.Final.jar
<org.jboss.weld.probe.Resource$11: void get(org.jboss.weld.probe.JsonDataProvider,java.lang.String[],javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse)> C:\Users\Flipped\.m2\repository\org\jboss\weld\probe\weld-probe-core\2.3.2.Final\weld-probe-core-2.3.2.Final.jar
<org.jboss.weld.probe.DefaultJsonDataProvider: java.lang.String receiveEvents(int,int,java.lang.String)> C:\Users\Flipped\.m2\repository\org\jboss\weld\probe\weld-probe-core\2.3.2.Final\weld-probe-core-2.3.2.Final.jar
<org.jboss.weld.probe.Probe: java.util.List getEvents()> C:\Users\Flipped\.m2\repository\org\jboss\weld\probe\weld-probe-core\2.3.2.Final\weld-probe-core-2.3.2.Final.jar
<com.google.common.collect.Lists$TransformingRandomAccessList: java.util.ListIterator listIterator(int)>
```

By further analyzing, I found that the caller **<org.jboss.weld.probe.Resource: void handle(org.jboss.weld.probe.Resource$HttpMethod,org.jboss.weld.probe.JsonDataProvider,java.lang.String[],javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse)>** would invoke the method **AbstractList.listIterator(int)** defined in the superclass of **Lists$TransformingRandomAccessList (Lists$TransformingRandomAccessList extends AbstractList)** with the same signature of the expected callee, due to dynamic binding mechanism.

Although the actual invoked method belonging to **AbstractList** has the same method name, same parameter types and return type as the expected method defined in its subclass **Lists$TransformingRandomAccessList**, but it has different control flows and different behaviors. Maybe it is buggy behavior.

### Solution:
Use the newer version **com.google.guava:guava:jar:18.0** to keep the version consistency.

**Dependency tree----**
[INFO] org.ops4j.pax.exam:pax-exam-container-weld:jar:4.13.1
[INFO] +- org.kohsuke.metainf-services:metainf-services:jar:1.2:provided
[INFO] +- org.ops4j.pax.exam:pax-exam-cdi:jar:4.13.1:compile
[INFO] |  \- org.ops4j.pax.exam:pax-exam:jar:4.13.1:compile
[INFO] |     +- org.ops4j.base:ops4j-base-lang:jar:1.5.0:compile
[INFO] |     +- org.ops4j.base:ops4j-base-store:jar:1.5.0:compile
[INFO] |     |  +- (org.slf4j:slf4j-api:jar:1.7.25:compile - version managed from 1.5.11; omitted for duplicate)
[INFO] |     |  \- org.ops4j.base:ops4j-base-io:jar:1.5.0:compile
[INFO] |     |     +- (org.ops4j.base:ops4j-base-lang:jar:1.5.0:compile - omitted for duplicate)
[INFO] |     |     \- org.ops4j.base:ops4j-base-monitors:jar:1.5.0:compile
[INFO] |     \- org.ops4j.base:ops4j-base-util-property:jar:1.5.0:compile
[INFO] +- org.ops4j.pax.exam:pax-exam-spi:jar:4.13.1:compile
[INFO] |  +- (org.ops4j.pax.exam:pax-exam:jar:4.13.1:compile - omitted for duplicate)
[INFO] |  +- org.ops4j.base:ops4j-base-spi:jar:1.5.0:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
[INFO] |  \- org.ops4j.pax.tinybundles:tinybundles:jar:2.1.1:compile
[INFO] |     +- (org.ops4j.base:ops4j-base-store:jar:1.5.0:compile - omitted for duplicate)
[INFO] |     \- biz.aQute.bnd:bndlib:jar:2.4.0:compile
[INFO] +- org.jboss.weld.se:weld-se-core:jar:2.3.2.Final:compile
[INFO] |  +- org.jboss.weld.environment:weld-environment-common:jar:2.3.2.Final:compile
[INFO] |  |  \- org.jboss.weld:weld-core-impl:jar:2.3.2.Final:compile
[INFO] |  |     +- org.jboss.weld:weld-api:jar:2.3.Final:compile
[INFO] |  |     |  \- javax.inject:javax.inject:jar:1:compile
[INFO] |  |     +- org.jboss.weld:weld-spi:jar:2.3.Final:compile
[INFO] |  |     |  +- (javax.inject:javax.inject:jar:1:compile - omitted for duplicate)
[INFO] |  |     |  \- (org.jboss.weld:weld-api:jar:2.3.Final:compile - omitted for duplicate)
[INFO] |  |     +- org.jboss.classfilewriter:jboss-classfilewriter:jar:1.1.2.Final:compile
[INFO] |  |     +- (org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:1.0.0.Final:compile - omitted for duplicate)
[INFO] |  |     +- **com.google.guava:guava:jar:14.0:compile (version managed from 18.0)**
[INFO] |  |     +- org.jboss.spec.javax.el:jboss-el-api_3.0_spec:jar:1.0.0.Alpha1:compile
[INFO] |  |     +- org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec:jar:1.0.0.Final:compile
[INFO] |  |     \- org.jboss.logging:jboss-logging:jar:3.1.0.GA:compile (version managed from 3.2.1.Final)
[INFO] |  +- org.jboss.weld.probe:weld-probe-core:jar:2.3.2.Final:compile
[INFO] |  |  \- (org.jboss.weld:weld-core-impl:jar:2.3.2.Final:compile - omitted for duplicate)
[INFO] |  \- org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:1.0.0.Final:compile
[INFO] +- org.apache.geronimo.specs:geronimo-atinject_1.0_spec:jar:1.0:provided
[INFO] \- javax.enterprise:cdi-api:jar:1.2:provided
[INFO]    +- javax.el:javax.el-api:jar:3.0.0:provided
[INFO]    +- javax.interceptor:javax.interceptor-api:jar:1.2:provided
[INFO]    \- (javax.inject:javax.inject:jar:1:compile - scope updated from provided; omitted for duplicate)


Thanks!
Best regards,
Coco
