### PR TITLE
[PAXEXAM-926] RMI port range is not configurable for forked container

### DIFF
--- a/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactory.java
+++ b/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactory.java
@@ -17,6 +17,10 @@
  */
 package org.ops4j.pax.exam.forked;
 
+import static org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT;
+import static org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND;
+import static org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT_RANGE_UPPERBOUND;
+
 import java.io.File;
 import java.net.InetAddress;
 import java.net.URISyntaxException;
@@ -105,9 +109,7 @@ public class ForkedFrameworkFactory {
     public RemoteFramework fork(List<String> vmArgs, Map<String, String> systemProperties,
         Map<String, Object> frameworkProperties, List<String> beforeFrameworkClasspath,
         List<String> afterFrameworkClasspath) {
-        // TODO make port range configurable
-        FreePort freePort = new FreePort(21000, 21099);
-        port = freePort.getPort();
+        port = getPort();
         LOG.debug("using RMI registry at port {}", port);
 
         String rmiName = "ExamRemoteFramework-" + UUID.randomUUID().toString();
@@ -130,6 +132,18 @@ public class ForkedFrameworkFactory {
         }
         catch (RemoteException | ExecutionException | URISyntaxException exc) {
             throw new TestContainerException(exc);
+        }
+    }
+
+    protected int getPort() {
+        String configuredPort = System.getProperty(EXAM_FORKED_INVOKER_PORT);
+        if (configuredPort != null) {
+            return Integer.parseInt(configuredPort);
+        } else {
+            // fails if user configure a wrong port value
+            int lowerBound = Integer.parseInt(System.getProperty(EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND, "21000"));
+            int upperBound = Integer.parseInt(System.getProperty(EXAM_FORKED_INVOKER_PORT_RANGE_UPPERBOUND, "21099"));
+            return new FreePort(lowerBound, upperBound).getPort();
         }
     }
 

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
@@ -30,7 +30,9 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -145,6 +147,24 @@ public class ForkedFrameworkFactoryTest {
         forkedFactory.fork(Collections.<String> emptyList(),
             Collections.<String, String> emptyMap(), frameworkProperties, null,
             bootClasspath);
+    }
+
+    @Test()
+    public void verifyPortConfiguration() throws Exception {
+        ForkedFrameworkFactory frameworkFactory = new ForkedFrameworkFactory(null);
+
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT, "15000") {
+            @Override
+            protected void doRun() {
+                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+            }
+        }.run();
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND, "15000") {
+            @Override
+            protected void doRun() {
+                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+            }
+        }.run();
     }
 
     private File generateBundle() throws IOException {

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
 import org.junit.Test;
 import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.ExamSystem;
@@ -125,6 +127,24 @@ public class ForkedTestContainerFactoryTest {
         container.installProbe(new FileInputStream(testBundle));
 
         container.stop();
+    }
+
+    @Test()
+    public void verifyPortConfiguration() throws Exception {
+        ForkedFrameworkFactory frameworkFactory = new ForkedFrameworkFactory(null);
+
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT, "15000") {
+            @Override
+            protected void doRun() {
+                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+            }
+        }.run();
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT_RANGE_LOWERBOUND, "15000") {
+            @Override
+            protected void doRun() {
+                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+            }
+        }.run();
     }
 
     private File generateBundle() throws IOException {

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/SystemPropertyRunnable.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/SystemPropertyRunnable.java
@@ -1,0 +1,29 @@
+package org.ops4j.pax.exam.forked;
+
+/*package */ abstract class SystemPropertyRunnable implements Runnable {
+
+    private String name;
+    private String value;
+
+    public SystemPropertyRunnable(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+    
+    @Override
+    public void run() {
+        String existingValue = null;
+        try {
+            existingValue = System.setProperty(name, value);
+            doRun();
+        } finally {
+            if (existingValue == null) {
+                System.clearProperty(name);
+            } else {
+                System.setProperty(name, existingValue);
+            }
+        }
+    }
+
+    protected abstract void doRun();
+}

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/Constants.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/Constants.java
@@ -133,6 +133,31 @@ public class Constants {
      */
     public static final String EXAM_INVOKER_PORT = "pax.exam.invoker.port";
 
+    /**
+     * Lower bound port range for socket-based communication with remote invoker.
+     */
+    public static final String EXAM_INVOKER_PORT_RANGE_LOWERBOUND = "pax.exam.invoker.port.range.lowerbound";
+
+    /**
+     * Upper bound port range for socket-based communication with remote invoker.
+     */
+    public static final String EXAM_INVOKER_PORT_RANGE_UPPERBOUND = "pax.exam.invoker.port.range.upperbound";
+
+    /**
+     * Port for socket-based communication with remote invoker.
+     */
+    public static final String EXAM_FORKED_INVOKER_PORT = "pax.exam.forked.invoker.port";
+
+    /**
+     * Lower bound port range for socket-based communication with forked remote invoker.
+     */
+    public static final String EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND = "pax.exam.forked.invoker.port.range.lowerbound";
+
+    /**
+     * Upper bound port range for socket-based communication with forked remote invoker.
+     */
+    public static final String EXAM_FORKED_INVOKER_PORT_RANGE_UPPERBOUND = "pax.exam.forked.invoker.port.range.upperbound";
+
     /** Hidden utility class constructor. */
     private Constants() {
     }


### PR DESCRIPTION
Make socket-based communication for invoker and RMI of forked container configurable through system properties.

If you agree to change some method visibility I could test using mockito otherwise I should use PowerMockito to enable mock of private methods and final classes.