### PR TITLE
[PAXEXAM-930] Any filter applied to the JUnitCore is honored the unit tests are invoker in the container

### DIFF
--- a/core/pax-exam-invoker-junit/src/main/java/org/ops4j/pax/exam/invoker/junit/internal/JUnitProbeInvoker.java
+++ b/core/pax-exam-invoker-junit/src/main/java/org/ops4j/pax/exam/invoker/junit/internal/JUnitProbeInvoker.java
@@ -33,6 +33,7 @@ import org.junit.runners.model.InitializationError;
 import org.ops4j.pax.exam.ProbeInvoker;
 import org.ops4j.pax.exam.TestContainerException;
 import org.ops4j.pax.exam.TestDescription;
+import org.ops4j.pax.exam.TestFilter;
 import org.ops4j.pax.exam.TestListener;
 import org.ops4j.pax.exam.util.Exceptions;
 import org.ops4j.pax.exam.util.Injector;
@@ -95,6 +96,19 @@ public class JUnitProbeInvoker implements ProbeInvoker {
                 Description methodName = Description
                     .createTestDescription(description.getClassName(), description.getMethodName());
                 runner.filter(Filter.matchMethodDescription(methodName));
+            }
+            TestFilter customFilter = description.getFilter();
+            if (customFilter != null) {
+                runner.filter(new Filter() {
+                    @Override
+                    public boolean shouldRun(Description description) {
+                        return customFilter.getUniqueIds().contains(String.valueOf(description.hashCode()));
+                    }
+                    @Override
+                    public String describe() {
+                        return customFilter.getDescription();
+                    }
+                });
             }
 
             JUnitCore junit = new JUnitCore();

--- a/core/pax-exam-invoker-junit/src/test/java/org/ops4j/pax/exam/invoker/junit/internal/CustomFilterSimpleTestHidden.java
+++ b/core/pax-exam-invoker-junit/src/test/java/org/ops4j/pax/exam/invoker/junit/internal/CustomFilterSimpleTestHidden.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019, Nikolas Falco
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam.invoker.junit.internal;
+
+import org.junit.Test;
+
+public class CustomFilterSimpleTestHidden {
+
+    @Test
+    public void test1() {
+    }
+
+    @Test
+    public void test2() {
+    }
+
+    @Test
+    public void _test3() {
+    }
+
+    @Test
+    public void test4() {
+    }
+
+}

--- a/core/pax-exam-invoker-junit/src/test/java/org/ops4j/pax/exam/invoker/junit/internal/JUnitProbeInvokerTest.java
+++ b/core/pax-exam-invoker-junit/src/test/java/org/ops4j/pax/exam/invoker/junit/internal/JUnitProbeInvokerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Nikolas Falco
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam.invoker.junit.internal;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.ops4j.pax.exam.TestDescription;
+import org.ops4j.pax.exam.TestFilter;
+import org.ops4j.pax.exam.TestListener;
+import org.ops4j.pax.exam.util.Injector;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JUnitProbeInvokerTest {
+    @Mock
+    private BundleContext bundleContext;
+    @Mock
+    private Injector injector;
+    @Mock
+    private Bundle bundle;
+
+    @Test
+    public void testCustomFilter() throws Exception {
+        when(bundleContext.getBundle()).thenReturn(bundle);
+        doReturn(CustomFilterSimpleTestHidden.class).when(bundle).loadClass(CustomFilterSimpleTestHidden.class.getName());
+        JUnitProbeInvoker invoker = new JUnitProbeInvoker(bundleContext, injector);
+
+        TestFilter customFilter = createCustomFilter(CustomFilterSimpleTestHidden.class, new DescriptionPredicate() {
+            @Override
+            public boolean accept(Description description) {
+                return !description.getMethodName().startsWith("_");
+            }
+        });
+
+        TestDescription description = new TestDescription(CustomFilterSimpleTestHidden.class.getName(), null, null, customFilter);
+        TestListener listener = mock(TestListener.class);
+        invoker.runTest(description, listener);
+
+        verify(listener, times(3)).testStarted(any(TestDescription.class));
+    }
+
+    interface DescriptionPredicate {
+        boolean accept(Description description);
+    }
+
+    private TestFilter createCustomFilter(Class<?> testClass, DescriptionPredicate predicate) throws Exception {
+        final List<String> uniqueIds = new ArrayList<>();
+        Filter customFilter = new Filter() {
+            @Override
+            public boolean shouldRun(Description description) {
+                if (predicate.accept(description)) {
+                    uniqueIds.add(String.valueOf(description.hashCode()));
+                    return true;
+                };
+                return false;
+            }
+
+            @Override
+            public String describe() {
+                return "custom filter";
+            }
+        };
+        new BlockJUnit4ClassRunner(testClass).filter(customFilter);
+        TestFilter testFilter = new TestFilter(customFilter.describe(), uniqueIds);
+        return testFilter;
+    }
+
+}

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/TestDescription.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/TestDescription.java
@@ -30,12 +30,13 @@ public class TestDescription implements Serializable {
     private String className;
     private String methodName;
     private Integer index;
+    private TestFilter filter;
 
     /**
      *
      */
     public TestDescription(String className) {
-        this(className, null, null);
+        this(className, null);
     }
 
     public TestDescription(String className, String methodName) {
@@ -43,9 +44,14 @@ public class TestDescription implements Serializable {
     }
 
     public TestDescription(String className, String methodName, Integer index) {
+        this(className, methodName, index, null);
+    }
+
+    public TestDescription(String className, String methodName, Integer index, TestFilter filter) {
         this.className = nonEmpty(className);
         this.methodName = nonEmpty(methodName);
         this.index = index;
+        this.filter = filter;
     }
 
     private static String nonEmpty(String s) {
@@ -77,7 +83,9 @@ public class TestDescription implements Serializable {
         return index;
     }
 
-
+    public TestFilter getFilter() {
+        return this.filter;
+    }
 
     @Override
     public String toString() {
@@ -90,6 +98,10 @@ public class TestDescription implements Serializable {
         if (index != null) {
             builder.append(index);
         }
+        builder.append(':');
+        if (filter != null) {
+            builder.append(filter);
+        }
         return builder.toString();
     }
 
@@ -100,6 +112,7 @@ public class TestDescription implements Serializable {
         result = prime * result + ((className == null) ? 0 : className.hashCode());
         result = prime * result + ((index == null) ? 0 : index.hashCode());
         result = prime * result + ((methodName == null) ? 0 : methodName.hashCode());
+        result = prime * result + ((filter == null) ? 0 : filter.hashCode());
         return result;
     }
 
@@ -143,16 +156,26 @@ public class TestDescription implements Serializable {
     }
 
     public static TestDescription parse(String s) {
+        TestFilter filter = null;
+        Integer index = null;
+
         String[] parts = s.split(":");
         switch (parts.length) {
+            case 4:
+                if (nonEmpty(parts[3]) != null) {
+                    filter = TestFilter.parse(parts[3]);
+                }
+            case 3:
+                if (nonEmpty(parts[2]) != null) {
+                    index = Integer.parseInt(parts[2]);
+                }
+            case 2:
+                return new TestDescription(parts[0], parts[1], index, filter);
             case 1:
                 return new TestDescription(parts[0]);
-            case 2:
-                return new TestDescription(parts[0], parts[1]);
-            case 3:
-                return new TestDescription(parts[0], parts[1], Integer.parseInt(parts[2]));
             default:
                 throw new IllegalArgumentException(s);
         }
     }
+
 }

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/TestFilter.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/TestFilter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 Nikolas Falco
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.exam;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * Class to filter test methods.
+ *
+ * @author Nikolas Falco
+ */
+public class TestFilter implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final TestFilter ALL_METHODS = new TestFilter("All Methods");
+
+    private final List<String> uniqueIds;
+    private final String description;
+
+    public TestFilter(String description) {
+        this(description, null);
+    }
+
+    public TestFilter(String description, List<String> uniqueIds) {
+        this.description = description;
+        this.uniqueIds = uniqueIds == null ? new ArrayList<>() : new ArrayList<>(uniqueIds);
+    }
+
+    public void addUniqueId(String testUniqueId) {
+        this.uniqueIds.add(testUniqueId);
+    }
+
+    public List<String> getUniqueIds() {
+        return Collections.unmodifiableList(uniqueIds);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        if (description != null) {
+            builder.append(Base64.getEncoder().encodeToString(description.getBytes()));
+        }
+        builder.append(';');
+
+        Iterator<String> ids = uniqueIds.iterator();
+        while (ids.hasNext()) {
+            builder.append(ids.next());
+            if (ids.hasNext()) {
+                builder.append('#');
+            }
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((uniqueIds == null) ? 0 : uniqueIds.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        TestFilter other = (TestFilter) obj;
+        if (description == null) {
+            if (other.description != null) {
+                return false;
+            }
+        } else if (!description.equals(other.description)) {
+            return false;
+        }
+        if (uniqueIds == null) {
+            if (other.uniqueIds != null) {
+                return false;
+            }
+        } else if (!uniqueIds.equals(other.uniqueIds)) {
+            return false;
+        }
+        return true;
+    }
+
+    public static TestFilter parse(String s) {
+        StringTokenizer st = new StringTokenizer(s, ";");
+        if (!st.hasMoreTokens()) {
+            return new TestFilter(null);
+        }
+
+        String description = nonEmpty(st.nextToken());
+        if (description != null) {
+            description = new String(Base64.getDecoder().decode(description));
+        }
+
+        List<String> uniqueIds = Collections.emptyList();
+        if (st.hasMoreTokens()) {
+            uniqueIds = Arrays.asList(st.nextToken().split("#"));
+        }
+
+        if (st.hasMoreTokens()) {
+            throw new IllegalArgumentException(s);
+        }
+        return new TestFilter(description, uniqueIds);
+    }
+
+    private static String nonEmpty(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+
+}

--- a/core/pax-exam/src/test/java/org/ops4j/pax/exam/TestDescriptorTest.java
+++ b/core/pax-exam/src/test/java/org/ops4j/pax/exam/TestDescriptorTest.java
@@ -1,0 +1,27 @@
+package org.ops4j.pax.exam;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class TestDescriptorTest {
+
+    @Test
+    public void testParse() {
+        TestDescription descriptor = new TestDescription("className");
+        assertThat(descriptor, equalTo(TestDescription.parse(descriptor.toString())));
+
+        descriptor = new TestDescription("className", "methodName");
+        assertThat(descriptor, equalTo(TestDescription.parse(descriptor.toString())));
+
+        descriptor = new TestDescription("className", "methodName", 3);
+        assertThat(descriptor, equalTo(TestDescription.parse(descriptor.toString())));
+
+        descriptor = new TestDescription("className", "methodName", 3, new TestFilter("All methods", Arrays.asList("1", "2", "3")));
+        assertThat(descriptor, equalTo(TestDescription.parse(descriptor.toString())));
+    }
+
+}

--- a/core/pax-exam/src/test/java/org/ops4j/pax/exam/TestFilterTest.java
+++ b/core/pax-exam/src/test/java/org/ops4j/pax/exam/TestFilterTest.java
@@ -1,0 +1,25 @@
+package org.ops4j.pax.exam;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class TestFilterTest {
+
+    @Test
+    public void testParse() {
+        TestFilter filter = new TestFilter(null);
+        assertThat(filter, equalTo(TestFilter.parse(filter.toString())));
+
+        filter = new TestFilter("custom filter", Collections.emptyList());
+        assertThat(filter, equalTo(TestFilter.parse(filter.toString())));
+
+        filter = new TestFilter("custom filter", Arrays.asList("uniqueId1", "uniqueId2"));
+        assertThat(filter, equalTo(TestFilter.parse(filter.toString())));
+    }
+
+}

--- a/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/DriverExtension.java
+++ b/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/DriverExtension.java
@@ -27,6 +27,7 @@ import org.ops4j.pax.exam.Constants;
 import org.ops4j.pax.exam.ExamConfigurationException;
 import org.ops4j.pax.exam.TestDescription;
 import org.ops4j.pax.exam.TestFailure;
+import org.ops4j.pax.exam.TestFilter;
 import org.ops4j.pax.exam.TestListener;
 import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.impl.JUnitTestListener;
@@ -53,6 +54,8 @@ public class DriverExtension extends RunnerExtension {
     private StagedExamReactor stagedReactor;
 
     private ExtensibleRunner base;
+
+    private TestFilter filter;
 
     /**
      * @throws InitializationError
@@ -159,7 +162,8 @@ public class DriverExtension extends RunnerExtension {
     public void delegateClassBlock(RunNotifier notifier) {
         TestListener listener = new JUnitTestListener(notifier);
         try {
-            stagedReactor.runTest(new TestDescription(testClass.getName()), listener);
+            TestDescription description = new TestDescription(testClass.getName(), null, null, filter);
+            stagedReactor.runTest(description, listener);
         }
         // CHECKSTYLE:SKIP : StagedExamReactor API
         catch (Exception exc) {
@@ -182,5 +186,10 @@ public class DriverExtension extends RunnerExtension {
             testListener.testFailure(new TestFailure(description, exc));
             testListener.testFinished(description);
         }
+    }
+
+    @Override
+    public void setFilter(TestFilter filter) {
+        this.filter = filter;
     }
 }

--- a/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/ExtensibleRunner.java
+++ b/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/ExtensibleRunner.java
@@ -19,6 +19,7 @@ package org.ops4j.pax.exam.junit;
 
 import java.util.List;
 
+import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runner.notification.RunNotifier;
@@ -26,6 +27,7 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
+import org.ops4j.pax.exam.TestFilter;
 
 /**
  * @author hwellmann
@@ -70,6 +72,13 @@ public class ExtensibleRunner extends BlockJUnit4ClassRunner {
     public void filter(Filter filter) throws NoTestsRemainException {
         spyingFilter = new SpyingFilter(filter);
         super.filter(spyingFilter);
+
+        TestFilter testFilter = new TestFilter(filter.describe());
+        for (Description description : spyingFilter.getMatchingChildren()) {
+            // description hash code delegate to fUniqueId that mean to be is unique again
+            testFilter.addUniqueId(String.valueOf(description.hashCode()));
+        }
+        extension.setFilter(testFilter);
     }
 
     @Override

--- a/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/RunnerExtension.java
+++ b/drivers/pax-exam-junit4/src/main/java/org/ops4j/pax/exam/junit/RunnerExtension.java
@@ -19,6 +19,7 @@ package org.ops4j.pax.exam.junit;
 
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;
+import org.ops4j.pax.exam.TestFilter;
 
 /**
  * @author hwellmann
@@ -55,4 +56,8 @@ public class RunnerExtension {
     public Object processTestInstance(Object test) {
         return test;
     }
+
+    public void setFilter(TestFilter filter) {
+    }
+
 }


### PR DESCRIPTION
We are using the latest beta 5.0 to obtain the support for Before/After Class.
When we want to run exactly a specific test method of a test suite from eclipse IDE for example we got that all test are executed. The same issue happens in maven when the rerun feature is enabled. The point is that when we got a failure all tests in the test suite are re-executed. This means increase build time and sometimes the failure of test flaky that was passed on the first run.

The root cause is that the list of filtered out methods are not passed when the OSGi service junit invoker is called.
Unfortunally when a filter (I mean a simple method descriptor filter) is applied to the JUnitCore instance it apply this filter internally saving the filtered list of descriptor that must be executed. This internal state is not accessible and this means is not possible to move forward to the OSGi service container.

This patch allow to register any filter applied to the JUnitCore instance collecting all fUniqueId that should be run. These ids are than saved into test descriptor. When the probe instructs the container service than re-apply the filter to the JUnitCore instance to filter out all junit description that does not matches any collected fUniqueId.