### PR TITLE
Add jdk9plus lib directory to karaf classpath.

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/KarafTestContainer.java
@@ -566,6 +566,16 @@ public class KarafTestContainer implements TestContainer {
                 cp.add(jar.toString());
             }
         }
+        
+        File [] jdk9Plus = new File(karafHome + "/lib/jdk9plus")
+            .listFiles((FileFilter) new WildcardFileFilter("*.jar"));
+        
+        if (jdk9Plus != null) {
+            for (File jar : jdk9Plus) {
+                cp.add(jar.toString());
+            }
+        }
+        
         return cp.toArray(new String[] {});
     }
 


### PR DESCRIPTION
Currently Karaf startup files include adding lib/jdk9plus to the classpath if the jdk is beyond 8.  Libraries that require JavaEE libraries that have been removed in Java 11 fail without this.

https://github.com/apache/karaf/blob/43207e4cfcd2619483a84da90dd78077c4bdd9d7/assemblies/features/base/src/main/filtered-resources/resources/bin/karaf.bat#L318