### PR TITLE
fixing karaf embedded runner

### DIFF
--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
@@ -64,6 +64,7 @@ public class ForkedFrameworkFactoryTest {
     public void afterTest() throws IOException {
         // FileUtils.deleteDirectory(storage);
         storage = null;
+        System.clearProperty(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT); // set implicitly
     }
 
     @Test

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.ops4j.pax.exam.CoreOptions.options;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -34,7 +35,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.osgi.launch.EquinoxFactory;
 import org.hamcrest.CoreMatchers;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.ops4j.pax.exam.CoreOptions;
@@ -44,6 +47,7 @@ import org.ops4j.pax.exam.TestContainer;
 import org.ops4j.pax.exam.TestContainerException;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.UrlReference;
+import org.ops4j.pax.exam.spi.DefaultExamSystem;
 import org.ops4j.pax.exam.spi.PaxExamRuntime;
 import org.ops4j.pax.tinybundles.core.TinyBundles;
 import org.osgi.framework.BundleActivator;
@@ -52,6 +56,10 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
 public class ForkedTestContainerFactoryTest {
+    @After
+    public void reset() {
+        System.clearProperty(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT); // set implicitly
+    }
 
     @Test
     public void withBootClasspathMvn() throws BundleException, IOException,
@@ -131,18 +139,19 @@ public class ForkedTestContainerFactoryTest {
 
     @Test()
     public void verifyPortConfiguration() throws Exception {
-        ForkedFrameworkFactory frameworkFactory = new ForkedFrameworkFactory(null);
+        ForkedTestContainer container = new ForkedTestContainer(
+                DefaultExamSystem.create(options()), new EquinoxFactory());
 
         new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT, "15000") {
             @Override
             protected void doRun() {
-                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+                Assert.assertThat(container.getPort(), CoreMatchers.equalTo(15000));
             }
         }.run();
         new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT_RANGE_LOWERBOUND, "15000") {
             @Override
             protected void doRun() {
-                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+                Assert.assertThat(container.getPort(), CoreMatchers.equalTo(15000));
             }
         }.run();
     }

--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/runner/KarafEmbeddedRunner.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/runner/KarafEmbeddedRunner.java
@@ -16,8 +16,16 @@
  */
 package org.ops4j.pax.exam.karaf.container.internal.runner;
 
+import static java.util.Collections.emptyList;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -25,17 +33,20 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-
-import org.ops4j.pax.exam.TestContainerException;
+import java.util.Properties;
+import java.util.stream.Stream;
 
 /**
- * Very simple asynchronous implementation of Java Runner. Exec is being invoked
- * in a fresh Thread.
+ * Very simple asynchronous implementation of Java Runner.
+ * Exec is being invoked in a fresh Thread.
  */
 public class KarafEmbeddedRunner implements Runner {
 
     private InternalRunner runner;
+    private List<Runnable> resetTasks;
 
     public KarafEmbeddedRunner() {
         runner = new InternalRunner();
@@ -44,110 +55,266 @@ public class KarafEmbeddedRunner implements Runner {
     @Override
     @SuppressWarnings("deprecation")
     public synchronized void // CHECKSTYLE:SKIP : more than 10 params
-    exec(final String[] environment, final File karafBase, final String javaHome, final String[] javaOpts,
-            final String[] javaEndorsedDirs, final String[] javaExtDirs, final String karafHome, final String karafData,
-            final String karafEtc, final String karafLog, final String[] karafOpts, final String[] opts, final String[] classPath,
-            final String main, final String options, final boolean security) {
-        Thread thread = new Thread("KarafEmbeddedRunner") {
-            @Override
-            public void run() {
-                String cp = buildCmdSeparatedString(classPath);
+    exec(final String[] environment, final File base, final String javaHome,
+         final String[] javaOpts, final String[] javaEndorsedDirs, final String[] javaExtDirs,
+         final String home, final String data, final String etc, final String log,
+         final String[] karafOpts, final String[] opts, final String[] classpath,
+         final String main, final String options, final boolean security) {
+        new Thread(
+            () -> doMain(base, home, data, etc, log, karafOpts, opts, classpath, main, options),
+            "KarafEmbeddedRunner")
+        .start();
+    }
 
-                System.setProperty("karaf.instances", karafHome + "/instances");
-                System.setProperty("karaf.home", karafHome);
-                System.setProperty("karaf.base", karafBase.getAbsolutePath());
-                System.setProperty("karaf.data", karafData);
-                System.setProperty("karaf.etc", karafEtc);
-                System.setProperty("karaf.log", karafLog);
-                System.setProperty("java.util.logging.config.file", karafEtc + "/java.util.logging.properties");
+    private void  // CHECKSTYLE:SKIP : more than 10 params
+    doMain(final File karafBase,
+           final String karafHome, final String karafData, final String karafEtc, final String karafLog,
+           final String[] karafOpts, final String[] opts, final String[] classPath,
+           final String main, final String options) {
+        final String cp = String.join(File.pathSeparator, classPath);
 
-                final CommandLineBuilder commandLine = new CommandLineBuilder();
-                commandLine.append(karafOpts).append(opts).append("-cp").append(cp).append(options);
+        resetTasks = new ArrayList<>();
+        resetTasks.add(setSystemProperty("karaf.instances", karafHome + "/instances"));
+        resetTasks.add(setSystemProperty("karaf.home", karafHome));
+        resetTasks.add(setSystemProperty("karaf.base", karafBase.getAbsolutePath()));
+        resetTasks.add(setSystemProperty("karaf.data", karafData));
+        resetTasks.add(setSystemProperty("karaf.etc", karafEtc));
+        resetTasks.add(setSystemProperty("karaf.log", karafLog));
+        resetTasks.add(setSystemProperty("java.util.logging.config.file", karafEtc + "/java.util.logging.properties"));
 
-                try {
-                    String[] arguments = commandLine.toArray();
+        final CommandLineBuilder commandLine = new CommandLineBuilder();
+        commandLine.append(karafOpts).append(opts).append("-cp").append(cp).append(options);
+        try {
+            final String[] arguments = commandLine.toArray();
 
-                    File mainBundlePath = new File(karafBase, "lib");
-                    List<File> mainBundles = searchMainBundle(mainBundlePath.listFiles());
-
-                    if (null != mainBundles && !mainBundles.isEmpty()) {
-
-                        URL[] bundleUrls = new URL[mainBundles.size()];
-                        for (int i = 0; i < mainBundles.size(); i++) {
-                            bundleUrls[i] = mainBundles.get(i).toURL();
-                        }
-
-                        Class<?> mainClass = loadClass(bundleUrls, main);
-                        Constructor<?> constructor = mainClass.getConstructor(String[].class);
-                        constructor.setAccessible(true);
-                        Object karafInstance = constructor.newInstance(new Object[] { arguments });
-                        Method method = mainClass.getMethod("launch", (Class<?>[]) null);
-                        method.invoke(karafInstance, (Object[]) null);
-                    } 
-                    else {
-                        throw new RuntimeException("No Karaf main found");
+            final File mainBundlePath = new File(karafBase, "lib");
+            final List<File> mainBundles = searchMainBundle(mainBundlePath.listFiles());
+            final Thread thread = Thread.currentThread();
+            try {
+                // if endorsed is not set, add it to the classpath,
+                // will work in degraded mode most of the time
+                thread.getContextClassLoader()
+                        .loadClass("org.apache.karaf.specs.locator.OsgiLocator");
+            } catch (final ClassNotFoundException cnfe) {
+                final File endorsed = new File(mainBundlePath, "endorsed");
+                if (endorsed.exists()) {
+                    mainBundles.addAll(ofNullable(endorsed.listFiles(
+                            (dir, name) -> name.endsWith(".jar")))
+                            .map(Stream::of).map(s -> s.collect(toList()))
+                            .orElseGet(Collections::emptyList));
+                }
+            }
+            if (!mainBundles.isEmpty()) {
+                final URL[] bundleUrls = mainBundles.stream().map(it -> {
+                    try {
+                        return it.toURI().toURL();
+                    } catch (final MalformedURLException e) {
+                        throw new IllegalArgumentException(e);
                     }
+                }).toArray(URL[]::new);
 
-                } 
-                catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-                        | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
-                        | SecurityException | MalformedURLException e) {
-                    throw new RuntimeException(e);
-                }
-
-            }
-
-            private Class<?> loadClass(URL[] bundleUrls, final String main) throws ClassNotFoundException {
-                try (URLClassLoader urlCl = new URLClassLoader(bundleUrls, this.getContextClassLoader())) {
-                    return urlCl.loadClass(main);
-                }
-                catch (IOException e) {
-                    throw new TestContainerException(e.getMessage(), e);
-                }
-            }
-
-            private String buildCmdSeparatedString(final String[] splitted) {
-                final StringBuilder together = new StringBuilder();
-                for (String path : splitted) {
-                    if (together.length() != 0) {
-                        together.append(File.pathSeparator);
-                    }
-                    together.append(path);
-                }
-                return together.toString();
-            }
-
-            private List<File> searchMainBundle(File[] files) {
-
-                List<File> mainBundles = new ArrayList<File>();
-
-                for (File file : files) {
-                    if (file.isDirectory() && file.getName().contains("boot")) {
-                        // Karaf4 style
-                        mainBundles.addAll(searchMainBundle(file.listFiles()));
-                    } 
-                    else {
-                        if (file.getPath().contains(File.separator + "boot")) {
-                            // karaf 4.x
-                            mainBundles.add(file);
-                        } 
-                        else if (file.getName().startsWith("karaf") && file.getName().endsWith(".jar")) {
-                            // karaf version 3.x
-                            mainBundles.add(file);
+                final File jrePropsFile = new File(karafBase, "etc/jre.properties");
+                final Properties jreProps = loadProps(jrePropsFile);
+                final File configPropsFile = new File(karafBase, "etc/config.properties");
+                final Properties configProps = loadProps(configPropsFile);
+                if (!configProps.isEmpty()) {
+                    final String property = configProps.getProperty("org.osgi.framework.bootdelegation");
+                    if (property != null && !property.contains("com.intellij.rt.")) {
+                        try (final OutputStream outputStream = new FileOutputStream(configPropsFile)) {
+                            configProps.put("org.osgi.framework.bootdelegation", property + ",com.intellij.rt.*");
+                            configProps.store(outputStream, "adding intellij in delegation");
+                        } catch (final IOException e) {
+                            throw new IllegalStateException(e);
                         }
                     }
                 }
-                return mainBundles;
+
+                final URLClassLoader urlCl = new MainClassLoader(bundleUrls, new FilteringClassLoader(
+                        thread.getContextClassLoader(),
+                        findJre(jreProps, configProps)));
+                resetTasks.add(() -> {
+                    try {
+                        urlCl.close();
+                    } catch (final IOException e) {
+                        // no-op: not important
+                    }
+                });
+                thread.setContextClassLoader(urlCl); // no need to reset, this thread is single use
+                final Class<?> mainClass = urlCl.loadClass(main);
+                final Constructor<?> constructor = mainClass.getConstructor(String[].class);
+                constructor.setAccessible(true);
+                final Object karafInstance = constructor.newInstance(new Object[]{arguments});
+                final Method method = mainClass.getMethod("launch", (Class<?>[]) null);
+                method.invoke(karafInstance, (Object[]) null);
+            } else {
+                throw new RuntimeException("No Karaf main found");
             }
 
+        } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException
+                | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+                | SecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Runnable setSystemProperty(final String key, final String value) {
+        final String old = System.getProperty(key);
+        System.setProperty(key, value);
+        return () -> {
+            if (old == null) {
+                System.clearProperty(key);
+            } else {
+                System.setProperty(key, value);
+            }
         };
-        thread.start();
+    }
+
+    private Properties loadProps(final File file) {
+        final Properties props = new Properties();
+        if (file.exists()) {
+            try (final InputStream stream = new FileInputStream(file)) {
+                props.load(stream);
+            } catch (final IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        return props;
+    }
+
+    private List<File> searchMainBundle(final File[] files) {
+        final List<File> mainBundles = new ArrayList<File>();
+        if (files == null) {
+            return mainBundles;
+        }
+        for (final File file : files) {
+            if (file.isDirectory() && isBoot(file)) {
+                // Karaf4 style
+                mainBundles.addAll(searchMainBundle(file.listFiles()));
+            } else {
+                if (isBoot(file.getParentFile())) {
+                    if (file.getName().endsWith(".jar")) {
+                        // karaf 4.x
+                        mainBundles.add(file);
+                    } // else ignore (README for ex.)
+                } else if (file.getName().startsWith("karaf") && file.getName().endsWith(".jar")) {
+                    // karaf version 3.x
+                    mainBundles.add(file);
+                }
+            }
+        }
+        return mainBundles;
+    }
+
+    private boolean isBoot(final File file) {
+        return file != null && file.getName().equals("boot");
+    }
+
+    private Collection<String> findJre(final Properties jreProps, final Properties configProps) {
+        final List<String> exclusions = getForcedOsgiPackages().collect(toList());
+        return Stream.concat(
+                findJreProp(jreProps).stream(),
+                toVersions(configProps.getProperty("org.osgi.framework.bootdelegation", "")).stream()
+                        .filter(it -> !it.startsWith("org.apache.karaf.")))
+                .filter(it -> exclusions.stream().noneMatch(it::startsWith))
+                .collect(toList());
+    }
+
+    private Collection<String> findJreProp(final Properties jreProps) {
+        if (jreProps.isEmpty()) {
+            return getEnforcedParentPackages().collect(toList());
+        }
+        final String version = System.getProperty("java.version", "1.8");
+
+        String key;
+        if (version.startsWith("1.8")) { // 7, 6 etc... are not supported so we only need to take care of it
+            key = "jre-1.8";
+        } else {
+            final int sep = version.indexOf(".");
+            try {
+                key = "jre-" + Integer.parseInt(version.substring(0, sep));
+            } catch (final NumberFormatException nfe) {
+                key = "jre-1.8"; // fallback, should be most of the time ok
+            }
+        }
+        return Stream.concat(
+                getEnforcedParentPackages(),
+                toVersions(jreProps.getProperty(key)).stream())
+                .collect(toList());
+    }
+
+    private Stream<String> getEnforcedParentPackages() {
+        return Stream.concat(Stream.of("java."), getCustomJvmPackages());
+    }
+
+    // let user customize it otherwise it is hard to be right for all stacks
+    private Stream<String> getCustomJvmPackages() {
+        final Collection<String> config = toVersions(System.getProperty(getClass().getName() + ".customJvmPackages"));
+        if (config.isEmpty()) { // default is IDE friendly
+            return Stream.of("com.intellij.rt.");
+        }
+        return config.stream();
+    }
+
+    // let user customize it otherwise it is hard to be right for all stacks
+    private Stream<String> getForcedOsgiPackages() {
+        final Collection<String> config = toVersions(System.getProperty(getClass().getName() + ".forcedOSGiPackages"));
+        if (config.isEmpty()) { // default is IDE friendly
+            return Stream.empty();
+        }
+        return config.stream();
+    }
+
+    private Collection<String> toVersions(final String property) {
+        return property == null ?
+                emptyList() :
+                Stream.of(property.split(","))
+                        .map(String::trim)
+                        .map(it -> {
+                            final int sep = it.indexOf(";");
+                            return sep > 0 ? it.substring(0, sep) : it;
+                        })
+                        .map(it -> it.endsWith("*") ? it.substring(0, it.length() - 1) : it)
+                        .collect(toList());
     }
 
     @Override
     public synchronized void shutdown() {
         runner.shutdown();
-
+        if (resetTasks != null) {
+            resetTasks.forEach(Runnable::run);
+            resetTasks.clear();
+        }
     }
 
+    private static class MainClassLoader extends URLClassLoader {
+        static {
+            registerAsParallelCapable();
+        }
+
+        public MainClassLoader(final URL[] urls, final ClassLoader parent) {
+            super(urls, parent);
+        }
+    }
+
+    private static class FilteringClassLoader extends ClassLoader {
+        static {
+            registerAsParallelCapable();
+        }
+
+        private final Collection<String> packages;
+
+        public FilteringClassLoader(final ClassLoader contextClassLoader,
+                                    final Collection<String> packages) {
+            super(contextClassLoader);
+            this.packages = packages;
+        }
+
+        @Override // let only the JVM filter from this parent classloader to isolate the container from the tests
+        protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+            if (name != null && packages.stream().noneMatch(name::startsWith)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
 }

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/AbstractKarafTestContainerITest.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/AbstractKarafTestContainerITest.java
@@ -35,6 +35,8 @@ import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ConfigurationManager;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionBaseConfigurationOption;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.osgi.framework.Bundle;
@@ -51,12 +53,20 @@ public abstract class AbstractKarafTestContainerITest {
 
     @Configuration
     public Option[] config() {
+        return doConfig();
+    }
+
+    protected Option[] doConfig() {
         String karafVersion = karafVersion();
         return new Option[] {
-            karafDistributionConfiguration().frameworkUrl(KARAF_URL.version(karafVersion))
+            distribution().frameworkUrl(KARAF_URL.version(karafVersion))
                 .karafVersion(karafVersion).useDeployFolder(false).unpackDirectory(new File("target/paxexam/unpack/")),
             configureConsole().startLocalConsole().ignoreRemoteShell(), logLevel(LogLevel.INFO)
         };
+    }
+
+    protected KarafDistributionBaseConfigurationOption distribution() {
+        return karafDistributionConfiguration();
     }
 
     public String karafVersion() {

--- a/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/Karaf4EmbeddedTestContainerITest.java
+++ b/containers/pax-exam-container-karaf/src/test/java/org/ops4j/pax/exam/karaf/container/Karaf4EmbeddedTestContainerITest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ops4j.pax.exam.karaf.container;
+
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+
+import java.util.stream.Stream;
+
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionBaseConfigurationOption;
+
+public class Karaf4EmbeddedTestContainerITest extends AbstractKarafTestContainerITest {
+
+    @Override
+    protected String getDefaultKarafVersion() {
+        return "4.1.1";
+    }
+
+    @Override
+    protected KarafDistributionBaseConfigurationOption distribution() {
+        return super.distribution().runEmbedded(true);
+    }
+
+    @Override
+    protected Option[] doConfig() {
+        return Stream.concat(Stream.of(super.config()), Stream.of(keepRuntimeFolder())).toArray(Option[]::new);
+    }
+}


### PR DESCRIPTION
Embedded runner does not isolate test classloader (jvm) from OSGi container leading to not matching classes (at least in felix).

This PR ensures the test classloader only leaks JVM classes.

Side note: I got some issues running tests, I fixed a few but Karaf ones don't run for me with NoClassDefFoundError in karaf options - even before the diff, not sure what I did wrong.