### PR TITLE
(Back)port of PAXEXAM-926 (RMI port range is not configurable for forked container) towards the v4.x branch

### DIFF
--- a/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactory.java
+++ b/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactory.java
@@ -17,6 +17,10 @@
  */
 package org.ops4j.pax.exam.forked;
 
+import static org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT;
+import static org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND;
+import static org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT_RANGE_UPPERBOUND;
+
 import java.io.File;
 import java.net.InetAddress;
 import java.net.URISyntaxException;
@@ -104,9 +108,7 @@ public class ForkedFrameworkFactory {
     public RemoteFramework fork(List<String> vmArgs, Map<String, String> systemProperties,
         Map<String, Object> frameworkProperties, List<String> beforeFrameworkClasspath,
         List<String> afterFrameworkClasspath) {
-        // TODO make port range configurable
-        FreePort freePort = new FreePort(21000, 21099);
-        port = freePort.getPort();
+        port = getPort();
         LOG.debug("using RMI registry at port {}", port);
 
         String rmiName = "ExamRemoteFramework-" + UUID.randomUUID().toString();
@@ -129,6 +131,18 @@ public class ForkedFrameworkFactory {
         }
         catch (RemoteException | ExecutionException | URISyntaxException exc) {
             throw new TestContainerException(exc);
+        }
+    }
+
+    protected int getPort() {
+        String configuredPort = System.getProperty(EXAM_FORKED_INVOKER_PORT);
+        if (configuredPort != null) {
+            return Integer.parseInt(configuredPort);
+        } else {
+            // fails if user configure a wrong port value
+            int lowerBound = Integer.parseInt(System.getProperty(EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND, "21000"));
+            int upperBound = Integer.parseInt(System.getProperty(EXAM_FORKED_INVOKER_PORT_RANGE_UPPERBOUND, "21099"));
+            return new FreePort(lowerBound, upperBound).getPort();
         }
     }
 

--- a/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedTestContainer.java
+++ b/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedTestContainer.java
@@ -18,9 +18,6 @@
 package org.ops4j.pax.exam.forked;
 
 import static org.ops4j.pax.exam.Constants.EXAM_FAIL_ON_UNRESOLVED_KEY;
-import static org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT;
-import static org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT_RANGE_LOWERBOUND;
-import static org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT_RANGE_UPPERBOUND;
 import static org.ops4j.pax.exam.Constants.START_LEVEL_TEST_BUNDLE;
 import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.osgi.framework.Constants.FRAMEWORK_BOOTDELEGATION;
@@ -41,7 +38,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.ops4j.io.StreamUtils;
-import org.ops4j.net.FreePort;
 import org.ops4j.pax.exam.ConfigurationManager;
 import org.ops4j.pax.exam.ExamSystem;
 import org.ops4j.pax.exam.Option;
@@ -139,10 +135,8 @@ public class ForkedTestContainer implements TestContainer {
     @Override
     public TestContainer start() {
         try {
-            port = getPort();
             system = system.fork(new Option[] {
-                systemProperty("java.protocol.handler.pkgs").value("org.ops4j.pax.url"),
-                systemProperty(EXAM_INVOKER_PORT).value(Integer.toString(port))
+                systemProperty("java.protocol.handler.pkgs").value("org.ops4j.pax.url")
                 });
             List<String> vmArgs = createVmArguments();
             Map<String, String> systemProperties = createSystemProperties();
@@ -176,18 +170,6 @@ public class ForkedTestContainer implements TestContainer {
             throw new TestContainerException(exc);
         }
         return this;
-    }
-
-    protected int getPort() {
-        String configuredPort = System.getProperty(EXAM_INVOKER_PORT);
-        if (configuredPort != null) {
-            return Integer.parseInt(configuredPort);
-        } else {
-            // fails if user configure a wrong port value
-            int lowerBound = Integer.parseInt(System.getProperty(EXAM_INVOKER_PORT_RANGE_LOWERBOUND, "20000"));
-            int upperBound = Integer.parseInt(System.getProperty(EXAM_INVOKER_PORT_RANGE_UPPERBOUND, "21000"));
-            return new FreePort(lowerBound, upperBound).getPort();
-        }
     }
 
     @Override

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
@@ -66,6 +66,7 @@ public class ForkedFrameworkFactoryTest {
     public void afterTest() throws IOException {
         // FileUtils.deleteDirectory(storage);
         storage = null;
+        System.clearProperty(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT); // set implicitly
     }
 
     @Test

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
@@ -30,7 +30,9 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -147,6 +149,24 @@ public class ForkedFrameworkFactoryTest {
         forkedFactory.fork(Collections.<String> emptyList(),
             Collections.<String, String> emptyMap(), frameworkProperties, null,
             bootClasspath);
+    }
+
+    @Test()
+    public void verifyPortConfiguration() throws Exception {
+        ForkedFrameworkFactory frameworkFactory = new ForkedFrameworkFactory(null);
+
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT, "15000") {
+            @Override
+            protected void doRun() {
+                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+            }
+        }.run();
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND, "15000") {
+            @Override
+            protected void doRun() {
+                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+            }
+        }.run();
     }
 
     private File generateBundle() throws IOException {

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
@@ -66,7 +66,6 @@ public class ForkedFrameworkFactoryTest {
     public void afterTest() throws IOException {
         // FileUtils.deleteDirectory(storage);
         storage = null;
-        System.clearProperty(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT); // set implicitly
     }
 
     @Test

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.ExamSystem;
@@ -125,6 +126,24 @@ public class ForkedTestContainerFactoryTest {
         container.install(new FileInputStream(testBundle));
 
         container.stop();
+    }
+
+    @Test()
+    public void verifyPortConfiguration() throws Exception {
+        ForkedFrameworkFactory frameworkFactory = new ForkedFrameworkFactory(null);
+
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT, "15000") {
+            @Override
+            protected void doRun() {
+                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+            }
+        }.run();
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND, "15000") {
+            @Override
+            protected void doRun() {
+                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+            }
+        }.run();
     }
 
     private File generateBundle() throws IOException {

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
@@ -17,6 +17,8 @@
  */
 package org.ops4j.pax.exam.forked;
 
+import static org.ops4j.pax.exam.CoreOptions.options;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -27,8 +29,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
+import org.eclipse.osgi.launch.EquinoxFactory;
 import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.ExamSystem;
@@ -37,6 +41,7 @@ import org.ops4j.pax.exam.TestContainer;
 import org.ops4j.pax.exam.TestContainerException;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.UrlReference;
+import org.ops4j.pax.exam.spi.DefaultExamSystem;
 import org.ops4j.pax.exam.spi.PaxExamRuntime;
 import org.ops4j.pax.tinybundles.TinyBundles;
 import org.osgi.framework.BundleActivator;
@@ -47,6 +52,10 @@ import org.osgi.framework.Constants;
 import static org.ops4j.pax.tinybundles.TinyBundles.rawBuilder;
 
 public class ForkedTestContainerFactoryTest {
+    @After
+    public void reset() {
+        System.clearProperty(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT); // set implicitly
+    }
 
     @Test
     public void withBootClasspathMvn() throws BundleException, IOException,
@@ -130,18 +139,19 @@ public class ForkedTestContainerFactoryTest {
 
     @Test()
     public void verifyPortConfiguration() throws Exception {
-        ForkedFrameworkFactory frameworkFactory = new ForkedFrameworkFactory(null);
+        ForkedTestContainer container = new ForkedTestContainer(
+                DefaultExamSystem.create(options()), new EquinoxFactory());
 
-        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT, "15000") {
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT, "15000") {
             @Override
             protected void doRun() {
-                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+                Assert.assertThat(container.getPort(), CoreMatchers.equalTo(15000));
             }
         }.run();
-        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND, "15000") {
+        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT_RANGE_LOWERBOUND, "15000") {
             @Override
             protected void doRun() {
-                Assert.assertThat(frameworkFactory.getPort(), CoreMatchers.equalTo(15000));
+                Assert.assertThat(container.getPort(), CoreMatchers.equalTo(15000));
             }
         }.run();
     }

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
@@ -29,9 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
-import org.eclipse.osgi.launch.EquinoxFactory;
-import org.hamcrest.CoreMatchers;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.ops4j.pax.exam.CoreOptions;
@@ -41,7 +38,6 @@ import org.ops4j.pax.exam.TestContainer;
 import org.ops4j.pax.exam.TestContainerException;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.UrlReference;
-import org.ops4j.pax.exam.spi.DefaultExamSystem;
 import org.ops4j.pax.exam.spi.PaxExamRuntime;
 import org.ops4j.pax.tinybundles.TinyBundles;
 import org.osgi.framework.BundleActivator;
@@ -52,10 +48,6 @@ import org.osgi.framework.Constants;
 import static org.ops4j.pax.tinybundles.TinyBundles.rawBuilder;
 
 public class ForkedTestContainerFactoryTest {
-    @After
-    public void reset() {
-        System.clearProperty(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT); // set implicitly
-    }
 
     @Test
     public void withBootClasspathMvn() throws BundleException, IOException,
@@ -135,25 +127,6 @@ public class ForkedTestContainerFactoryTest {
         container.install(new FileInputStream(testBundle));
 
         container.stop();
-    }
-
-    @Test()
-    public void verifyPortConfiguration() throws Exception {
-        ForkedTestContainer container = new ForkedTestContainer(
-                DefaultExamSystem.create(options()), new EquinoxFactory());
-
-        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT, "15000") {
-            @Override
-            protected void doRun() {
-                Assert.assertThat(container.getPort(), CoreMatchers.equalTo(15000));
-            }
-        }.run();
-        new SystemPropertyRunnable(org.ops4j.pax.exam.Constants.EXAM_INVOKER_PORT_RANGE_LOWERBOUND, "15000") {
-            @Override
-            protected void doRun() {
-                Assert.assertThat(container.getPort(), CoreMatchers.equalTo(15000));
-            }
-        }.run();
     }
 
     private File generateBundle() throws IOException {

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/SystemPropertyRunnable.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/SystemPropertyRunnable.java
@@ -1,0 +1,29 @@
+package org.ops4j.pax.exam.forked;
+
+/*package */ abstract class SystemPropertyRunnable implements Runnable {
+
+    private String name;
+    private String value;
+
+    public SystemPropertyRunnable(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+    
+    @Override
+    public void run() {
+        String existingValue = null;
+        try {
+            existingValue = System.setProperty(name, value);
+            doRun();
+        } finally {
+            if (existingValue == null) {
+                System.clearProperty(name);
+            } else {
+                System.setProperty(name, existingValue);
+            }
+        }
+    }
+
+    protected abstract void doRun();
+}

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/Constants.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/Constants.java
@@ -19,14 +19,14 @@ package org.ops4j.pax.exam;
 
 /**
  * Pax Exam related constants.
- * 
+ *
  * @author Alin Dreghiciu (adreghiciu@gmail.com)
  * @author Harald Wellmann
  * @since 0.5.0, April 22, 2009
  */
 public class Constants {
-    
-    
+
+
     /**
      * The start level at which Pax Exam system bundles are to be started.
      */
@@ -121,12 +121,42 @@ public class Constants {
      * Do not provision any logging system and leave it to the user.
      */
     public static final String EXAM_LOGGING_NONE = "none";
-    
+
     /**
      * Should Pax Exam fail the test if any of the provisioned bundles is unresolved?
      * Values: true | false.
      */
     public static final String EXAM_FAIL_ON_UNRESOLVED_KEY = "pax.exam.osgi.unresolved.fail";
+
+    /**
+     * Port for socket-based communication with remote invoker.
+     */
+    public static final String EXAM_INVOKER_PORT = "pax.exam.invoker.port";
+
+    /**
+     * Lower bound port range for socket-based communication with remote invoker.
+     */
+    public static final String EXAM_INVOKER_PORT_RANGE_LOWERBOUND = "pax.exam.invoker.port.range.lowerbound";
+
+    /**
+     * Upper bound port range for socket-based communication with remote invoker.
+     */
+    public static final String EXAM_INVOKER_PORT_RANGE_UPPERBOUND = "pax.exam.invoker.port.range.upperbound";
+
+    /**
+     * Port for socket-based communication with remote invoker.
+     */
+    public static final String EXAM_FORKED_INVOKER_PORT = "pax.exam.forked.invoker.port";
+
+    /**
+     * Lower bound port range for socket-based communication with forked remote invoker.
+     */
+    public static final String EXAM_FORKED_INVOKER_PORT_RANGE_LOWERBOUND = "pax.exam.forked.invoker.port.range.lowerbound";
+
+    /**
+     * Upper bound port range for socket-based communication with forked remote invoker.
+     */
+    public static final String EXAM_FORKED_INVOKER_PORT_RANGE_UPPERBOUND = "pax.exam.forked.invoker.port.range.upperbound";
 
     /** Hidden utility class constructor. */
     private Constants() {

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/Constants.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/Constants.java
@@ -131,21 +131,6 @@ public class Constants {
     /**
      * Port for socket-based communication with remote invoker.
      */
-    public static final String EXAM_INVOKER_PORT = "pax.exam.invoker.port";
-
-    /**
-     * Lower bound port range for socket-based communication with remote invoker.
-     */
-    public static final String EXAM_INVOKER_PORT_RANGE_LOWERBOUND = "pax.exam.invoker.port.range.lowerbound";
-
-    /**
-     * Upper bound port range for socket-based communication with remote invoker.
-     */
-    public static final String EXAM_INVOKER_PORT_RANGE_UPPERBOUND = "pax.exam.invoker.port.range.upperbound";
-
-    /**
-     * Port for socket-based communication with remote invoker.
-     */
     public static final String EXAM_FORKED_INVOKER_PORT = "pax.exam.forked.invoker.port";
 
     /**


### PR DESCRIPTION
I've prepared a (back)port of an enhancement that was previously merged towards master (PAXEXAM-926). This enhancement is about being able to configure the RMI port (range) of a forked container. 

This is particular useful features when running tests in parallel through surefire/failsafe's fork feature:

```xml
<configuration>
    <systemPropertyVariables>
        <pax.exam.forked.invoker.port.range.lowerbound>1${surefire.forkNumber}000</pax.exam.forked.invoker.port.range.lowerbound>
        <pax.exam.forked.invoker.port.range.upperbound>1${surefire.forkNumber}009</pax.exam.forked.invoker.port.range.upperbound>
    </systemPropertyVariables>
    <forkCount>2</forkCount>
</configuration>
```

Without this enhancement, the parallel execution of the tests in most cases fail due to multiple tests trying to claim the same RMI port at the same time.

The original commits used (by cherrie-picking):

* a6270b9 by @nfalco79 which was the initial commit of this feature (PAXEXAM-926)
* 2b4a85e by @rmannibucau which contained some improvements related to the unit tests of this feature.