### PR TITLE
Add support for EnvironmentOption to pax-exam-container-forked

### DIFF
--- a/containers/pax-exam-container-forked/pom.xml
+++ b/containers/pax-exam-container-forked/pom.xml
@@ -120,6 +120,11 @@
             <artifactId>org.eclipse.osgi</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-junit4</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactory.java
+++ b/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactory.java
@@ -102,7 +102,7 @@ public class ForkedFrameworkFactory {
      */
     public RemoteFramework fork(List<String> vmArgs, Map<String, String> systemProperties,
         Map<String, Object> frameworkProperties, List<String> beforeFrameworkClasspath,
-        List<String> afterFrameworkClasspath) {
+        List<String> afterFrameworkClasspath, String[] env) {
 
         try {
             final String address = InetAddress.getLoopbackAddress().getHostAddress();
@@ -120,7 +120,7 @@ public class ForkedFrameworkFactory {
 
             javaRunner = new ExamJavaRunner(false);
             javaRunner.exec(vmOptions, buildClasspath(beforeFrameworkClasspath, afterFrameworkClasspath),
-                RemoteFrameworkImpl.class.getName(), args, getJavaHome(), null);
+                RemoteFrameworkImpl.class.getName(), args, getJavaHome(), null, env);
             return findRemoteFramework(port, name);
         }
         catch (RemoteException | ExecutionException | URISyntaxException exc) {
@@ -143,7 +143,7 @@ public class ForkedFrameworkFactory {
      */
     public RemoteFramework fork(List<String> vmArgs, Map<String, String> systemProperties,
         Map<String, Object> frameworkProperties) {
-        return fork(vmArgs, systemProperties, frameworkProperties, null, null);
+        return fork(vmArgs, systemProperties, frameworkProperties, null, null, new String[0]);
     }
 
     private String[] buildSystemProperties(List<String> vmArgs, Map<String, String> systemProperties) {

--- a/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedTestContainer.java
+++ b/containers/pax-exam-container-forked/src/main/java/org/ops4j/pax/exam/forked/ForkedTestContainer.java
@@ -55,6 +55,7 @@ import org.ops4j.pax.exam.options.SystemPackageOption;
 import org.ops4j.pax.exam.options.SystemPropertyOption;
 import org.ops4j.pax.exam.options.UrlReference;
 import org.ops4j.pax.exam.options.ValueOption;
+import org.ops4j.pax.exam.options.extra.EnvironmentOption;
 import org.ops4j.pax.exam.options.extra.RepositoryOption;
 import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.swissbox.framework.RemoteFramework;
@@ -159,8 +160,15 @@ public class ForkedTestContainer implements TestContainer {
                 }
             }
 
+            List<String> environment = new ArrayList<>();
+            EnvironmentOption[] environmentOptions = system.getOptions(EnvironmentOption.class);
+            for (EnvironmentOption environmentOption : environmentOptions) {
+                environment.add(environmentOption.getEnvironment());
+            }
+            String[] env = environment.toArray(new String[environment.size()]);
+
             remoteFramework = frameworkFactory.fork(vmArgs, systemProperties, frameworkProperties,
-                beforeFrameworkClasspath, afterFrameworkClasspath);
+                beforeFrameworkClasspath, afterFrameworkClasspath, env);
             remoteFramework.init();
             installAndStartBundles();
         }

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedFrameworkFactoryTest.java
@@ -118,7 +118,7 @@ public class ForkedFrameworkFactoryTest {
             "org.kohsuke.metainf_services");
         RemoteFramework framework = forkedFactory.fork(Collections.<String> emptyList(),
             systemProperties, frameworkProperties, null,
-            bootClasspath);
+            bootClasspath, new String[0]);
         framework.start();
 
         File testBundle = generateBundle();
@@ -153,7 +153,7 @@ public class ForkedFrameworkFactoryTest {
             "org.kohsuke.metainf_services");
         forkedFactory.fork(Collections.<String> emptyList(),
             Collections.<String, String> emptyMap(), frameworkProperties, null,
-            bootClasspath);
+            bootClasspath, new String[0]);
     }
 
     private File generateBundle() throws IOException {

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
@@ -27,7 +27,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
+import org.hamcrest.core.StringStartsWith;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.ExamSystem;
@@ -36,16 +40,23 @@ import org.ops4j.pax.exam.TestContainer;
 import org.ops4j.pax.exam.TestContainerException;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.UrlReference;
+import org.ops4j.pax.exam.options.extra.EnvironmentOption;
 import org.ops4j.pax.exam.spi.PaxExamRuntime;
 import org.ops4j.pax.tinybundles.TinyBundles;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
+import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
 
 import static org.ops4j.pax.tinybundles.TinyBundles.rawBuilder;
 
 public class ForkedTestContainerFactoryTest {
+
+    @Rule
+    public EnvironmentVariablesRule environment = new EnvironmentVariablesRule(
+            "PROPAGATE", "test"
+    );
 
     @Test
     public void withBootClasspathMvn() throws BundleException, IOException,
@@ -150,6 +161,129 @@ public class ForkedTestContainerFactoryTest {
 
             if (clazz == null) {
                 throw new IllegalStateException("Class '" + className + "' not loaded");
+            }
+        }
+
+        @Override
+        public void stop(BundleContext bc) throws Exception {}
+    }
+
+    @Test
+    public void withEnvironmentPassthrough() throws IOException {
+        // This test only works if the environment variable 'PROPAGATE' is set externally to 'test'
+        Assert.assertTrue(System.getenv().containsKey("PROPAGATE"));
+        Assert.assertThat(System.getenv().get("PROPAGATE"), IsEqual.equalTo("test"));
+
+        List<Option> options = new ArrayList<>();
+        // Configure the EnvironmentOption to passthrough the 'PROPAGATE' environment variable
+        options.add(new EnvironmentOption("PROPAGATE"));
+        options.add(CoreOptions.frameworkProperty("test.expected.variable").value("PROPAGATE"));
+        options.add(CoreOptions.frameworkProperty("test.expected.value").value("test"));
+
+        forkWithEnvironment(options);
+    }
+
+    @Test
+    public void withEnvironmentOverride() throws IOException {
+        // This test only works if the environment variable 'PROPAGATE' is set externally to 'test'
+        Assert.assertTrue(System.getenv().containsKey("PROPAGATE"));
+        Assert.assertThat(System.getenv().get("PROPAGATE"), IsEqual.equalTo("test"));
+
+        List<Option> options = new ArrayList<>();
+        // Configure the EnvironmentOption to override the value of environment variable PROPAGATE
+        options.add(new EnvironmentOption("PROPAGATE=testOverride"));
+        options.add(CoreOptions.frameworkProperty("test.expected.variable").value("PROPAGATE"));
+        options.add(CoreOptions.frameworkProperty("test.expected.value").value("testOverride"));
+
+        forkWithEnvironment(options);
+    }
+
+    @Test
+    public void withEnvironmentDefinition() throws IOException {
+        List<Option> options = new ArrayList<>();
+        // Configure the EnvironmentOption to define environment variable OTHER
+        options.add(new EnvironmentOption("OTHER=value"));
+        options.add(CoreOptions.frameworkProperty("test.expected.variable").value("OTHER"));
+        options.add(CoreOptions.frameworkProperty("test.expected.value").value("value"));
+
+        forkWithEnvironment(options);
+    }
+
+    @Test
+    public void withoutEnvironmentPassthrough() throws IOException {
+        // This test only works if the environment variable 'PROPAGATE' is set externally to 'test'
+        Assert.assertTrue(System.getenv().containsKey("PROPAGATE"));
+        Assert.assertThat(System.getenv().get("PROPAGATE"), IsEqual.equalTo("test"));
+
+        List<Option> options = new ArrayList<>();
+        // Do not configure a value or pass through of environment variable PROPAGATE
+        options.add(CoreOptions.frameworkProperty("test.expected.variable").value("PROPAGATE"));
+        options.add(CoreOptions.frameworkProperty("test.expected.value").value("test"));
+
+        // The fork should fail as the expected environment variable is not found
+        TestContainerException testContainerException = Assert.assertThrows(TestContainerException.class, () -> forkWithEnvironment(options));
+
+        Throwable bundleException = testContainerException.getCause();
+        Assert.assertThat(bundleException, IsInstanceOf.instanceOf(BundleException.class));
+
+        Throwable illegalStateException = bundleException.getCause();
+        Assert.assertThat(illegalStateException, IsInstanceOf.instanceOf(IllegalStateException.class));
+
+        // Verify the reason of the failure
+        Assert.assertThat(illegalStateException.getMessage(), StringStartsWith.startsWith("Unable to find environment variable 'PROPAGATE' with expected value 'test'"));
+    }
+
+    public void forkWithEnvironment(List<Option> options) throws IOException {
+        Option[] opts = options.toArray(new Option[options.size()]);
+
+        ExamSystem system = PaxExamRuntime.createServerSystem(opts);
+        ForkedTestContainerFactory factory = new ForkedTestContainerFactory();
+        TestContainer[] containers = factory.create(system);
+
+        Assert.assertNotNull(containers);
+        Assert.assertNotNull(containers[0]);
+
+        ForkedTestContainer container = (ForkedTestContainer) containers[0];
+        container.start();
+        try {
+            // Prepare a test bundle with EnvironmentTestActivator as activator
+            File testBundle = generateEnvironmentBundle();
+
+            // Install the test bundle, the start on EnvironmentTestActivator will fail if the configured environment
+            // variable does not have the expected value
+            container.install(new FileInputStream(testBundle));
+        } finally {
+            container.stop();
+        }
+    }
+
+    private File generateEnvironmentBundle() throws IOException {
+        InputStream stream = TinyBundles.bundle().addClass(EnvironmentTestActivator.class)
+                .setHeader(Constants.BUNDLE_MANIFESTVERSION, "2")
+                .setHeader(Constants.BUNDLE_SYMBOLICNAME, "environment.test.generated")
+                .setHeader(Constants.BUNDLE_ACTIVATOR, EnvironmentTestActivator.class.getName())
+                .setHeader(Constants.IMPORT_PACKAGE, "org.osgi.framework")
+                .build(rawBuilder());
+
+        File bundle = new File("target/bundles/environment-generated.jar");
+        FileUtils.copyInputStreamToFile(stream, bundle);
+        return bundle;
+    }
+
+    public static class EnvironmentTestActivator implements BundleActivator {
+
+        @Override
+        public void start(BundleContext bc) throws Exception {
+            final String variable = bc.getProperty("test.expected.variable");
+            final String expectedValue = bc.getProperty("test.expected.value");
+            if (variable == null || expectedValue == null) {
+                throw new IllegalStateException("Unable to retrieve value for framework property " +
+                        "'test.expected.variable' and/or 'test.expected.value'");
+            }
+            if (!System.getenv().containsKey(variable) || !expectedValue.equals(System.getenv().get(variable))) {
+                throw new IllegalStateException(
+                        "Unable to find environment variable '" + variable +
+                                "' with expected value '" + expectedValue + "' in: " + System.getenv());
             }
         }
 

--- a/core/pax-exam/src/main/java/org/ops4j/pax/exam/ExamJavaRunner.java
+++ b/core/pax-exam/src/main/java/org/ops4j/pax/exam/ExamJavaRunner.java
@@ -20,8 +20,10 @@ package org.ops4j.pax.exam;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.ops4j.exec.CommandLineBuilder;
 import org.ops4j.exec.ExecutionException;
@@ -134,13 +136,59 @@ public class ExamJavaRunner implements StoppableJavaRunner, ProcessProvider {
     }
 
     private void setEnv(final String[] envOptions, ProcessBuilder pb) {
-        HashSet<String> envSet = new HashSet<String>(Arrays.asList(envOptions));
-        Map<String, String> env = pb.environment();
-        HashSet<String> toRemove = new HashSet<String>(env.keySet());
-        toRemove.removeAll(envSet);
-        for (String key : toRemove) {
-            env.remove(key);
+        final Map<String, String> envMap = toKeyValueMap(envOptions);
+
+        final Map<String, String> env = pb.environment();
+
+        // Remove all items from the ProcessBuilder's environment,
+        // that are not explicitly referenced in the envMap's keyset
+        final Set<String> toRemove = new HashSet<String>(env.keySet());
+        toRemove.removeAll(envMap.keySet());
+        env.keySet().removeAll(toRemove);
+
+        // Any supplied values should be applied, possibly overriding an initial value from the ProcessBuilder.
+        envMap.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .forEach(entry -> env.put(entry.getKey(), entry.getValue()));
+    }
+
+    /**
+     * Converts an array of strings in the format "key=value" into a map of key-value pairs.
+     * If a string does not contain an '=' character, the entire string is treated as the key,
+     * and the corresponding value is set to {@code null}.
+     *
+     * @param envOptions an array of strings, each representing an environment option in the
+     *                   format "key=value". Strings without an '=' will have {@code null} as the value.
+     * @return a {@code Map<String, String>} where each key-value pair is derived from the input array.
+     *         Keys are extracted from the portion of the string before the first '=' character,
+     *         and values are extracted from the portion after the '=' character. If no '=' is
+     *         present, the value is set to {@code null}.
+     */
+    private static Map<String, String> toKeyValueMap(String[] envOptions) {
+        final Map<String, String> envMap = new HashMap<>();
+        for (String envOption : envOptions) {
+            if (envOption == null || envOption.isEmpty()) {
+                throw new IllegalArgumentException("Null or empty entry in envOptions");
+            }
+            final int equalsPosition = envOption.indexOf('=');
+            final String key;
+            final String value;
+            if (equalsPosition < 0) {
+                key = envOption;
+                value = null;
+            } else {
+                key = envOption.substring(0, equalsPosition);
+                value = envOption.substring(equalsPosition + 1);
+            }
+            if (key.isEmpty()) {
+                throw new IllegalArgumentException("Input " + envOption + " resulted in an empty key");
+            }
+            if (envMap.containsKey(key)) {
+                throw new IllegalArgumentException("Duplicate key found: " + key);
+            }
+            envMap.put(key, value);
         }
+        return envMap;
     }
 
     /**

--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -539,6 +539,13 @@
                 <artifactId>jersey-client</artifactId>
                 <version>2.42</version>
             </dependency>
+
+            <dependency>
+                <groupId>uk.org.webcompere</groupId>
+                <artifactId>system-stubs-junit4</artifactId>
+                <version>2.1.8</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
It is a slight variation on how the KarafJavaRunner interprets this option. It allows for:
* Passthrough of an externally defined variable: new EnvironmentOption("HOME")
* Setting the environment variable: new EnvironmentOption("VAR=value") 

The latter can of course also be used to redefine an externally existing environment variable.