### PR TITLE
Fix the unit test failures of pax-exam-container-forked on windows

### DIFF
--- a/containers/pax-exam-container-forked/pom.xml
+++ b/containers/pax-exam-container-forked/pom.xml
@@ -120,11 +120,6 @@
             <artifactId>org.eclipse.osgi</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>uk.org.webcompere</groupId>
-            <artifactId>system-stubs-junit4</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -175,6 +170,15 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <PROPAGATE>test</PROPAGATE>
+                    </environmentVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
+++ b/containers/pax-exam-container-forked/src/test/java/org/ops4j/pax/exam/forked/ForkedTestContainerFactoryTest.java
@@ -31,7 +31,6 @@ import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.StringStartsWith;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.ExamSystem;
@@ -47,16 +46,10 @@ import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
-import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
 
 import static org.ops4j.pax.tinybundles.TinyBundles.rawBuilder;
 
 public class ForkedTestContainerFactoryTest {
-
-    @Rule
-    public EnvironmentVariablesRule environment = new EnvironmentVariablesRule(
-            "PROPAGATE", "test"
-    );
 
     @Test
     public void withBootClasspathMvn() throws BundleException, IOException,

--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -552,13 +552,6 @@
             </dependency>
 
             <dependency>
-                <groupId>uk.org.webcompere</groupId>
-                <artifactId>system-stubs-junit4</artifactId>
-                <version>2.1.8</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2-mvstore</artifactId>
                 <version>2.4.240</version>


### PR DESCRIPTION
Replaced EnvironmentVariablesRule with supplying the environment variable through surefire configuration. The EnvironmentVariablesRule's manipulation of the ProcessEnvironment does not work together with the JVM on windows.